### PR TITLE
Upgrade to Rspec 3.0

### DIFF
--- a/github-pages-health-check.gemspec
+++ b/github-pages-health-check.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("net-dns", "~> 0.6")
   s.add_dependency("public_suffix", "~> 1.4")
-  s.add_development_dependency("rspec", "~> 2.14")
+  s.add_development_dependency("rspec", "~> 3.0")
   s.add_development_dependency("pry")
 
 end

--- a/spec/github-pages-health-check_spec.rb
+++ b/spec/github-pages-health-check_spec.rb
@@ -14,110 +14,110 @@ describe(GitHubPages::HealthCheck) do
 
   it "knows old IP addresses" do
     %w[204.232.175.78 207.97.227.245].each do |ip_address|
-      health_check.stub(:dns) { [a_packet(ip_address)] }
+      allow(health_check).to receive(:dns) { [a_packet(ip_address)] }
       expect(health_check.old_ip_address?).to be(true)
     end
 
-    health_check.stub(:dns) { [a_packet("1.2.3.4")] }
+    allow(health_check).to receive(:dns) { [a_packet("1.2.3.4")] }
     expect(health_check.old_ip_address?).to be(false)
   end
 
   it "knows when a domain is an A record" do
-    health_check.stub(:dns) { [a_packet("1.2.3.4")] }
+    allow(health_check).to receive(:dns) { [a_packet("1.2.3.4")] }
     expect(health_check.a_record?).to be(true)
     expect(health_check.cname_record?).to be(false)
   end
 
   it "known when a domain is a CNAME record" do
-    health_check.stub(:dns) { [cname_packet("pages.github.com")] }
+    allow(health_check).to receive(:dns) { [cname_packet("pages.github.com")] }
     expect(health_check.cname_record?).to be(true)
     expect(health_check.a_record?).to be(false)
   end
 
   it "knows what an apex domain is" do
-    health_check.stub(:domain) { "parkermoore.de" }
+    allow(health_check).to receive(:domain) { "parkermoore.de" }
     expect(health_check.apex_domain?).to be(true)
 
-    health_check.stub(:domain) { "bbc.co.uk" }
+    allow(health_check).to receive(:domain) { "bbc.co.uk" }
     expect(health_check.apex_domain?).to be(true)
   end
 
   it "knows when the domain is on cloudflare" do
-    health_check.stub(:dns) { [a_packet("108.162.196.20")] }
+    allow(health_check).to receive(:dns) { [a_packet("108.162.196.20")] }
     expect(health_check.cloudflare_ip?).to be(true)
 
-    health_check.stub(:dns) { [a_packet("1.1.1.1")] }
+    allow(health_check).to receive(:dns) { [a_packet("1.1.1.1")] }
     expect(health_check.cloudflare_ip?).to be(false)
   end
 
   it "knows a subdomain is not an apex domain" do
-    health_check.stub(:domain) { "blog.parkermoore.de" }
+    allow(health_check).to receive(:domain) { "blog.parkermoore.de" }
     expect(health_check.apex_domain?).to be(false)
 
-    health_check.stub(:domain) { "www.bbc.co.uk" }
+    allow(health_check).to receive(:domain) { "www.bbc.co.uk" }
     expect(health_check.apex_domain?).to be(false)
   end
 
   it "knows what should be an apex record" do
-    health_check.stub(:domain) { "parkermoore.de" }
+    allow(health_check).to receive(:domain) { "parkermoore.de" }
     expect(health_check.should_be_a_record?).to be(true)
 
-    health_check.stub(:domain) { "bbc.co.uk" }
+    allow(health_check).to receive(:domain) { "bbc.co.uk" }
     expect(health_check.should_be_a_record?).to be(true)
 
-    health_check.stub(:domain) { "blog.parkermoore.de" }
+    allow(health_check).to receive(:domain) { "blog.parkermoore.de" }
     expect(health_check.should_be_a_record?).to be(false)
 
-    health_check.stub(:domain) { "www.bbc.co.uk" }
+    allow(health_check).to receive(:domain) { "www.bbc.co.uk" }
     expect(health_check.should_be_a_record?).to be(false)
 
-    health_check.stub(:domain) { "foo.github.io" }
+    allow(health_check).to receive(:domain) { "foo.github.io" }
     expect(health_check.should_be_a_record?).to be(false)
 
-    health_check.stub(:domain) { "pages.github.com" }
+    allow(health_check).to receive(:domain) { "pages.github.com" }
     expect(health_check.should_be_a_record?).to be(false)
   end
 
   it "can determine a valid GitHub Pages CNAME value" do
     ["parkr.github.io", "mattr-.github.com"].each do |domain|
-      health_check.stub(:dns) { [cname_packet(domain)] }
+      allow(health_check).to receive(:dns) { [cname_packet(domain)] }
       expect(health_check.pointed_to_github_user_domain?).to be(true)
     end
     ["github.com", "ben.balter.com"].each do |domain|
-      health_check.stub(:dns) { [cname_packet(domain)] }
+      allow(health_check).to receive(:dns) { [cname_packet(domain)] }
       expect(health_check.pointed_to_github_user_domain?).to be(false)
     end
   end
 
   it "retrieves a site's dns record" do
-    health_check.stub(:domain) { "pages.github.com" }
+    allow(health_check).to receive(:domain) { "pages.github.com" }
     expect(health_check.dns.first.class).to eql(Net::DNS::RR::CNAME)
   end
 
   it "can detect pages domains" do
-    health_check.stub(:domain) { "pages.github.com" }
+    allow(health_check).to receive(:domain) { "pages.github.com" }
     expect(health_check.pages_domain?).to be(true)
 
-    health_check.stub(:domain) { "pages.github.io" }
+    allow(health_check).to receive(:domain) { "pages.github.io" }
     expect(health_check.pages_domain?).to be(true)
 
-    health_check.stub(:domain) { "pages.github.io." }
+    allow(health_check).to receive(:domain) { "pages.github.io." }
     expect(health_check.pages_domain?).to be(true)
   end
 
   it "doesn't detect non-pages domains as a pages domain" do
-    health_check.stub(:domain) { "github.com" }
+    allow(health_check).to receive(:domain) { "github.com" }
     expect(health_check.pages_domain?).to be(false)
 
-    health_check.stub(:domain) { "google.co.uk" }
+    allow(health_check).to receive(:domain) { "google.co.uk" }
     expect(health_check.pages_domain?).to be(false)
   end
 
   it "detects invalid doimains" do
-    health_check.stub(:domain) { "github.com" }
+    allow(health_check).to receive(:domain) { "github.com" }
     expect(health_check.valid_domain?).to be(true)
 
-    health_check.stub(:domain) { "github.invalid" }
+    allow(health_check).to receive(:domain) { "github.invalid" }
     expect(health_check.valid_domain?).to be(false)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require File.expand_path("../../lib/github-pages-health-check.rb", __FILE__)
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
+  config.raise_errors_for_deprecations!
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
- use `be(true)`, as `be_true` has turned into `be_truthy`, but it's too wishy-washy for what we're looking for. same for `false`
- stubbing is now `allow(obj).to receive(:method) { "some val to return" }`
- bumped gem in gemspec
