### PR TITLE
Follow redirects in GitHubPages::HealthCheck#served_by_pages?

### DIFF
--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -109,6 +109,9 @@ class GitHubPages
       scheme = github_domain? ? "https" : "http"
       uri = URI("#{scheme}://#{domain}")
       response = Net::HTTP.get_response(uri)
+      if response.is_a? Net::HTTPRedirection
+        response = Net::HTTP.get_response(uri)
+      end
       response.to_hash["server"] == ["GitHub.com"]
     rescue
       false

--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -110,7 +110,10 @@ class GitHubPages
       uri = URI("#{scheme}://#{domain}")
       response = Net::HTTP.get_response(uri)
       if response.is_a? Net::HTTPRedirection
-        response = Net::HTTP.get_response(uri)
+        for t in 1..3
+          response = Net::HTTP.get_response(uri)
+          break if response.is_a? Net::HTTPSuccess
+        end
       end
       response.to_hash["server"] == ["GitHub.com"]
     rescue

--- a/spec/github_pages_health_check_spec.rb
+++ b/spec/github_pages_health_check_spec.rb
@@ -144,6 +144,15 @@ describe(GitHubPages::HealthCheck) do
     expect(check.valid?).to eql(true)
   end
 
+  it "knows when an apex domain using A records is served by pages" do
+    # Tests this redirect scenario for apex domains using A records:
+    # › curl -I http://getbootstrap.com/
+    # HTTP/1.1 302 Found
+    # Location: /
+    check = GitHubPages::HealthCheck.new "getbootstrap.com"
+    expect(check.valid?).to eql(true)
+  end
+
   it "knows when a domain isn't served bt pages" do
     check = GitHubPages::HealthCheck.new "github.com"
     expect(check.valid?).to eql(false)

--- a/spec/github_pages_health_check_spec.rb
+++ b/spec/github_pages_health_check_spec.rb
@@ -153,7 +153,7 @@ describe(GitHubPages::HealthCheck) do
     expect(check.valid?).to eql(true)
   end
 
-  it "knows when a domain isn't served bt pages" do
+  it "knows when a domain isn't served by pages" do
     check = GitHubPages::HealthCheck.new "github.com"
     expect(check.valid?).to eql(false)
     expect(check.reason.class).to eql(GitHubPages::HealthCheck::NotServedByPages)


### PR DESCRIPTION
Many apex domains like http://getbootstrap.com/ use A records (rather than ALIAS/ANAME records):

```
› dig getbootstrap.com
;getbootstrap.com.		IN	A
getbootstrap.com.	9072	IN	A	192.30.252.154
getbootstrap.com.	9072	IN	A	192.30.252.153
```

GitHub Pages will sometimes respond with a `302 Found` for these domains:

```
› curl -I http://getbootstrap.com/
HTTP/1.1 302 Found
Location: /
```

Previously the GitHubPages::HealthCheck#served_by_pages? check could fail because it would make a request which would respond with a `302 Found` and the `Server: GitHub.com` header wouldn't be included in the response.

This fixes the issue by retrying the request, which should then result in a `200 OK` response which includes the `Server: GitHub.com` header.

/cc @benbalter 