### PR TITLE
Handle NXDOMAIN correctly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 language: ruby
 script: "script/cibuild"
+install:
+  - sudo bash -c 'echo search github.com >> /etc/resolv.conf'

--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -38,7 +38,7 @@ class GitHubPages
 
     # Returns an array of DNS answers
     def dns
-      @dns ||= without_warnings { Net::DNS::Resolver.start(domain).answer } if domain
+      @dns ||= without_warnings { Net::DNS::Resolver.start(absolute_domain).answer  } if domain
     rescue Exception
       false
     end
@@ -181,6 +181,14 @@ class GitHubPages
       result = block.call
       $VERBOSE = warn_level
       result
+    end
+
+    # Adjust `domain` so that it won't be searched for with /etc/resolv.conf's search rules.
+    #
+    #     GitHubPages::HealthCheck.new("anything.io").absolute_domain
+    #     => "anything.io."
+    def absolute_domain
+      domain.end_with?(".") ? domain : "#{domain}."
     end
   end
 end

--- a/spec/github_pages_health_check_spec.rb
+++ b/spec/github_pages_health_check_spec.rb
@@ -187,6 +187,9 @@ describe(GitHubPages::HealthCheck) do
   end
 
   it "does not resolve domains that do not exist" do
+    check = GitHubPages::HealthCheck.new "this-domain-does-not-exist-and-should-not-ever-exist.io."
+    expect(check.dns).to be_empty
+
     check = GitHubPages::HealthCheck.new "this-domain-does-not-exist-and-should-not-ever-exist.io"
     expect(check.dns).to be_empty
   end

--- a/spec/github_pages_health_check_spec.rb
+++ b/spec/github_pages_health_check_spec.rb
@@ -185,4 +185,9 @@ describe(GitHubPages::HealthCheck) do
     check = GitHubPages::HealthCheck.new "benbalter.github.io"
     expect(check.github_domain?).to eql(false)
   end
+
+  it "does not resolve domains that do not exist" do
+    check = GitHubPages::HealthCheck.new "this-domain-does-not-exist-and-should-not-ever-exist.io"
+    expect(check.dns).to be_empty
+  end
 end


### PR DESCRIPTION
In our prod environment, resolv.conf includes `search github.com`. This leads to pages-health-check returning OK for domains like `this-does-not-exist.io`, because:

```
$ host this-does-not-exist.io
this-does-not-exist.io.github.com is an alias for github.map.fastly.net.
github.map.fastly.net has address 199.27.75.133
```

* [x] failing test
* [x] make the test fail in travis
* [x] fix

cc @jdennes @github/pages 