### PR TITLE
Check if domain is proxied

### DIFF
--- a/github-pages-health-check.gemspec
+++ b/github-pages-health-check.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.add_dependency("public_suffix", "~> 1.4")
   s.add_dependency("typhoeus", "~> 0.7")
   s.add_development_dependency("rspec", "~> 3.0")
-  s.add_development_dependency("pry")
-  s.add_development_dependency("gem-release")
-
+  s.add_development_dependency("pry", "~> 0.10")
+  s.add_development_dependency("gem-release", "~> 0.7")
 end

--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -45,7 +45,7 @@ class GitHubPages
     #   3. A site that returns GitHub.com server headers, but isn't CNAME'd to a GitHub IP
     def proxied?
       return true if cloudflare_ip?
-      return false if pointed_to_github_pages_ip? || old_ip_address? || pointed_to_github_user_domain?
+      return false if pointed_to_github_pages_ip? || pointed_to_github_user_domain?
       served_by_pages?
     end
 

--- a/spec/github_pages_health_check_cloudflare_spec.rb
+++ b/spec/github_pages_health_check_cloudflare_spec.rb
@@ -23,7 +23,7 @@ describe(GitHubPages::HealthCheck::CloudFlare) do
     before { tempfile.unlink }
 
     it "raises an error" do
-      expect { instance.ranges }.to raise_error
+      expect { instance.ranges }.to raise_error "no implicit conversion of nil into String"
     end
   end
 

--- a/spec/github_pages_health_check_spec.rb
+++ b/spec/github_pages_health_check_spec.rb
@@ -198,11 +198,6 @@ describe(GitHubPages::HealthCheck) do
       expect(health_check.proxied?).to be(false)
     end
 
-    it "knows a site pointed to a legacy IP isn't proxied" do
-      allow(health_check).to receive(:dns) { [a_packet("204.232.175.78")] }
-      expect(health_check.proxied?).to be(false)
-    end
-
     it "detects proxied sites" do
       check = GitHubPages::HealthCheck.new "management.cio.gov"
       expect(check.proxied?).to eql(true)

--- a/spec/github_pages_health_check_spec.rb
+++ b/spec/github_pages_health_check_spec.rb
@@ -202,6 +202,11 @@ describe(GitHubPages::HealthCheck) do
       check = GitHubPages::HealthCheck.new "management.cio.gov"
       expect(check.proxied?).to eql(true)
     end
+
+    it "knows a site not served by pages isn't proxied" do
+      check = GitHubPages::HealthCheck.new "google.com"
+      expect(check.proxied?).to eql(true)
+    end
   end
 
   it "knows when the domain is a github domain" do

--- a/spec/github_pages_health_check_spec.rb
+++ b/spec/github_pages_health_check_spec.rb
@@ -205,7 +205,7 @@ describe(GitHubPages::HealthCheck) do
 
     it "knows a site not served by pages isn't proxied" do
       check = GitHubPages::HealthCheck.new "google.com"
-      expect(check.proxied?).to eql(true)
+      expect(check.proxied?).to eql(false)
     end
   end
 


### PR DESCRIPTION
This adds a `proxied?` method to check if a domain is served by pages, but is proxied by a third-party service. If so, the Health Check shouldn't raise CNAME/A record errors.

The logic is as follows. A domain is proxied if:

1. It's served by a Cloudflare IP (existing logic)
2. The site returns GitHub server headers and it isn't:
  1. Pointed at a GitHub Pages IP, or
  2. Pointed at a GitHub Pages domain

(I also cleaned up some new test-related warnings that recently appeared by explicitly defining an expected error and explicitly vendoring test dependencies)

/cc @github/pages, @konklone