### PR TITLE
Smarter Typhoeus options

### DIFF
--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -29,6 +29,20 @@ class GitHubPages
       192.30.252.154
     ]
 
+    class << self
+      def typhoeus_options
+        {
+          :followlocation  => true,
+          :timeout         => 10,
+          :accept_encoding => "gzip",
+          :method          => :head,
+          :headers         => {
+            "User-Agent"   => "Mozilla/5.0 (compatible; GitHub Pages Health Check/#{VERSION}; +https://github.com/github/pages-health-check)"
+          }
+        }
+      end
+    end
+
     def initialize(domain)
       @domain = domain
     end
@@ -131,7 +145,7 @@ class GitHubPages
     end
 
     def served_by_pages?
-      response = Typhoeus.head(uri, followlocation: true)
+      response = Typhoeus.head(uri, HealthCheck.typhoeus_options)
       response.success? && response.headers["Server"] == "GitHub.com"
     end
 

--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -29,19 +29,15 @@ class GitHubPages
       192.30.252.154
     ]
 
-    class << self
-      def typhoeus_options
-        {
-          :followlocation  => true,
-          :timeout         => 10,
-          :accept_encoding => "gzip",
-          :method          => :head,
-          :headers         => {
-            "User-Agent"   => "Mozilla/5.0 (compatible; GitHub Pages Health Check/#{VERSION}; +https://github.com/github/pages-health-check)"
-          }
+    TYPHOEUS_OPTIONS = {
+        :followlocation  => true,
+        :timeout         => 10,
+        :accept_encoding => "gzip",
+        :method          => :head,
+        :headers         => {
+          "User-Agent"   => "Mozilla/5.0 (compatible; GitHub Pages Health Check/#{VERSION}; +https://github.com/github/pages-health-check)"
         }
-      end
-    end
+      }
 
     def initialize(domain)
       @domain = domain
@@ -145,7 +141,7 @@ class GitHubPages
     end
 
     def served_by_pages?
-      response = Typhoeus.head(uri, HealthCheck.typhoeus_options)
+      response = Typhoeus.head(uri, TYPHOEUS_OPTIONS)
       response.success? && response.headers["Server"] == "GitHub.com"
     end
 

--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -30,14 +30,14 @@ class GitHubPages
     ]
 
     TYPHOEUS_OPTIONS = {
-        :followlocation  => true,
-        :timeout         => 10,
-        :accept_encoding => "gzip",
-        :method          => :head,
-        :headers         => {
-          "User-Agent"   => "Mozilla/5.0 (compatible; GitHub Pages Health Check/#{VERSION}; +https://github.com/github/pages-health-check)"
-        }
+      :followlocation  => true,
+      :timeout         => 10,
+      :accept_encoding => "gzip",
+      :method          => :head,
+      :headers         => {
+        "User-Agent"   => "Mozilla/5.0 (compatible; GitHub Pages Health Check/#{VERSION}; +https://github.com/github/pages-health-check)"
       }
+    }
 
     def initialize(domain)
       @domain = domain

--- a/spec/github_pages_health_check_spec.rb
+++ b/spec/github_pages_health_check_spec.rb
@@ -227,4 +227,9 @@ describe(GitHubPages::HealthCheck) do
     check = GitHubPages::HealthCheck.new "this-domain-does-not-exist-and-should-not-ever-exist.io"
     expect(check.dns).to be_empty
   end
+
+  it "returns the Typhoeus options" do
+    expected = Regexp.escape GitHubPages::HealthCheck::VERSION
+    expect(GitHubPages::HealthCheck.typhoeus_options[:headers]["User-Agent"]).to match(expected)
+  end
 end

--- a/spec/github_pages_health_check_spec.rb
+++ b/spec/github_pages_health_check_spec.rb
@@ -230,6 +230,6 @@ describe(GitHubPages::HealthCheck) do
 
   it "returns the Typhoeus options" do
     expected = Regexp.escape GitHubPages::HealthCheck::VERSION
-    expect(GitHubPages::HealthCheck.typhoeus_options[:headers]["User-Agent"]).to match(expected)
+    expect(GitHubPages::HealthCheck::TYPHOEUS_OPTIONS[:headers]["User-Agent"]).to match(expected)
   end
 end


### PR DESCRIPTION
This passes some sane defaults to typhoeus when performing the `served_by_pages?` check. Specifically:

* Only make a `HEAD` request to save bandwidth
* Accept gzip 
* Set a 10 second timeout
* Pass a custom user agent (Typhoeus is blocked in some cases)