### PR TITLE
Stub net requests when testing

### DIFF
--- a/github-pages-health-check.gemspec
+++ b/github-pages-health-check.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rspec", "~> 3.0")
   s.add_development_dependency("pry", "~> 0.10")
   s.add_development_dependency("gem-release", "~> 0.7")
+  s.add_development_dependency("webmock", "~> 1.21")
 end

--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -139,9 +139,15 @@ class GitHubPages
         :reason                         => reason
       }
     end
+    alias_method :to_h, :to_hash
 
     def served_by_pages?
       response = Typhoeus.head(uri, TYPHOEUS_OPTIONS)
+      # Workaround for webmock not playing nicely with Typhoeus redirects
+      # See https://github.com/bblimke/webmock/issues/237
+      if response.mock? && response.headers["Location"]
+        response = Typhoeus.head(response.headers["Location"], TYPHOEUS_OPTIONS)
+      end
       response.success? && response.headers["Server"] == "GitHub.com"
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,8 @@
-require File.expand_path("../../lib/github-pages-health-check.rb", __FILE__)
+require "bundler/setup"
+require 'webmock/rspec'
+require_relative "../lib/github-pages-health-check"
+
+WebMock.disable_net_connect!
 
 RSpec.configure do |config|
   config.raise_errors_for_deprecations!


### PR DESCRIPTION
This stubs out all the net requests related to [the proxy check](https://github.com/github/pages-health-check/pull/21) to make tests faster and more deterministic. With the exception of DNS calls, the test suite should make no net requests to live websites now.