### PR TITLE
Use addressable::uri to support domains with underscores

### DIFF
--- a/github-pages-health-check.gemspec
+++ b/github-pages-health-check.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency("net-dns", "~> 0.6")
   s.add_dependency("public_suffix", "~> 1.4")
   s.add_dependency("typhoeus", "~> 0.7")
+  s.add_dependency("addressable", "~> 2.3")
   s.add_development_dependency("rspec", "~> 3.0")
   s.add_development_dependency("pry", "~> 0.10")
   s.add_development_dependency("gem-release", "~> 0.7")

--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -85,7 +85,7 @@ class GitHubPages
     # Is this a valid domain that PublicSuffix recognizes?
     # Used as an escape hatch to prevent false positves on DNS checkes
     def valid_domain?
-      PublicSuffix.valid?(domain)
+      PublicSuffix.valid? domain
     end
 
     # Is this domain an SLD, meaning a CNAME would be innapropriate

--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -1,5 +1,6 @@
 require "net/dns"
 require "net/dns/resolver"
+require "addressable/uri"
 require "ipaddr"
 require "public_suffix"
 require "singleton"
@@ -84,7 +85,7 @@ class GitHubPages
     # Is this a valid domain that PublicSuffix recognizes?
     # Used as an escape hatch to prevent false positves on DNS checkes
     def valid_domain?
-      PublicSuffix.valid? domain
+      PublicSuffix.valid?(domain)
     end
 
     # Is this domain an SLD, meaning a CNAME would be innapropriate
@@ -123,6 +124,7 @@ class GitHubPages
 
     def to_hash
       {
+        :uri                            => uri.to_s,
         :proxied?                       => proxied?,
         :cloudflare_ip?                 => cloudflare_ip?,
         :old_ip_address?                => old_ip_address?,
@@ -216,7 +218,7 @@ class GitHubPages
     end
 
     def uri
-      @uri ||= URI("#{scheme}://#{domain}")
+      @uri ||= Addressable::URI.new(:host => domain, :scheme => scheme, :path => "/").normalize
     end
   end
 end

--- a/spec/github_pages_health_check_spec.rb
+++ b/spec/github_pages_health_check_spec.rb
@@ -142,7 +142,8 @@ describe(GitHubPages::HealthCheck) do
          to_return(:status => 200, :headers => {:server => "GitHub.com"})
 
       data = JSON.parse GitHubPages::HealthCheck.new("benbalter.com").to_json
-      expect(data.length).to eql(14)
+      expect(data.length).to eql(15)
+      expect(data.delete("uri")).to eql("http://benbalter.com/")
       data.each { |key, value| expect([true,false,nil].include?(value)).to eql(true) }
     end
 
@@ -186,6 +187,17 @@ describe(GitHubPages::HealthCheck) do
 
       check = GitHubPages::HealthCheck.new "management.cio.gov"
       expect(check.served_by_pages?).to eql(true)
+    end
+
+    # https://stackoverflow.com/questions/5208851/is-there-a-workaround-to-open-urls-containing-underscores-in-ruby
+    it "doesn't error out on domains with underscores" do
+      check = GitHubPages::HealthCheck.new "this_domain_is_valid.github.io"
+
+      stub_request(:head, "this_domain_is_valid.github.io").
+         to_return(:status => 200, :headers => {:server => "GitHub.com"})
+
+      expect(check.served_by_pages?).to eql(true)
+      expect(check.valid?).to eql(true)
     end
   end
 


### PR DESCRIPTION
Apparently the native URI class isn't fully RFC compliant and doesn't like domains with underscores. See https://stackoverflow.com/questions/5208851/is-there-a-workaround-to-open-urls-containing-underscores-in-ruby.