### PR TITLE
Properly detect if domain is served by pages for non-200 response codes

### DIFF
--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -150,7 +150,8 @@ class GitHubPages
       if response.mock? && response.headers["Location"]
         response = Typhoeus.head(response.headers["Location"], TYPHOEUS_OPTIONS)
       end
-      response.success? && response.headers["Server"] == "GitHub.com"
+      
+      (response.mock? || response.return_code == :ok) && response.headers["Server"] == "GitHub.com"
     end
 
     def to_json


### PR DESCRIPTION
Before we were using `response.success?` which returns `false` for non-200 response codes including 30x and 40x status. 

Even if a GitHub Pages site isn't set up (e.g., `/` 404s`), the `served_by_pages?` check should still be able to determine if it's the Pages server, so long as we're able to connect and we don't time out.

Note, when mocking response, `response.return_code` appears to be `nil`.

Cribbed from https://github.com/typhoeus/typhoeus/blob/35a4d5b6f7c818a0c11b0c1e10a20b30c754e169/lib/typhoeus/response/status.rb#L48-L50.