### PR TITLE
Require net-dns ~> 0.8

### DIFF
--- a/github-pages-health-check.gemspec
+++ b/github-pages-health-check.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
     "LICENSE.md"
   ]
 
-  s.add_dependency("net-dns", "~> 0.6")
+  s.add_dependency("net-dns", "~> 0.8")
   s.add_dependency("public_suffix", "~> 1.4")
   s.add_dependency("typhoeus", "~> 0.7")
   s.add_dependency("addressable", "~> 2.3")


### PR DESCRIPTION
This fixes an error where net-dns does not properly query some domains resulting in an `undefined method `first' for false:FalseClass` or `undefined method `value' for example.com. 1800 IN A XXX.XXX.XXX.XXX:Net::DNS::RR::A`