### PR TITLE
Add timeout to DNS check

### DIFF
--- a/lib/github-pages-health-check/errors/invalid_dns.rb
+++ b/lib/github-pages-health-check/errors/invalid_dns.rb
@@ -1,0 +1,9 @@
+class GitHubPages
+  class HealthCheck
+    class InvalidDNS < Error
+      def message
+        "Domain's DNS record could not be retrieved"
+      end
+    end
+  end
+end

--- a/lib/github-pages-health-check/version.rb
+++ b/lib/github-pages-health-check/version.rb
@@ -1,5 +1,5 @@
 class GitHubPages
   class HealthCheck
-    VERSION = "0.4.2"
+    VERSION = "0.5.0"
   end
 end

--- a/spec/github_pages_health_check_spec.rb
+++ b/spec/github_pages_health_check_spec.rb
@@ -90,7 +90,7 @@ describe(GitHubPages::HealthCheck) do
   end
 
   it "can determine when an apex domain is pointed at a GitHub Pages IP address" do
-    allow(health_check).to receive(:domain) { "getbootstrap.com" }
+    allow(health_check).to receive(:domain) { "githubuniverse.com" }
     expect(health_check.pointed_to_github_pages_ip?).to be(true)
   end
 
@@ -142,7 +142,7 @@ describe(GitHubPages::HealthCheck) do
          to_return(:status => 200, :headers => {:server => "GitHub.com"})
 
       data = JSON.parse GitHubPages::HealthCheck.new("benbalter.com").to_json
-      expect(data.length).to eql(15)
+      expect(data.length).to eql(16)
       expect(data.delete("uri")).to eql("http://benbalter.com/")
       data.each { |key, value| expect([true,false,nil].include?(value)).to eql(true) }
     end
@@ -281,5 +281,17 @@ describe(GitHubPages::HealthCheck) do
   it "returns the Typhoeus options" do
     expected = Regexp.escape GitHubPages::HealthCheck::VERSION
     expect(GitHubPages::HealthCheck::TYPHOEUS_OPTIONS[:headers]["User-Agent"]).to match(expected)
+  end
+
+  context "dns" do
+    it "knows when the DNS resolves" do
+      allow(health_check).to receive(:dns) { [a_packet("1.2.3.4")] }
+      expect(health_check.dns?).to be(true)
+    end
+
+    it "knows when the DNS doesn't resolve" do
+      allow(health_check).to receive(:dns) { nil }
+      expect(health_check.dns?).to be(false)
+    end
   end
 end


### PR DESCRIPTION
This creates a shared 10 second timeout between HTTP and DNS checks, and better guards against failing loudly if the DNS check fails for whatever reason.

If the DNS check fails, any check that relies on DNS will return nil, rather than returning a false positive/negative. Check! will return an InvalidDNS error.

Last, memoize served_by_pages? to save on subsequent calls (which may also timeout).

/cc @nuclearsandwich 