### PR TITLE
Memoize falsy values

### DIFF
--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -171,7 +171,7 @@ class GitHubPages
     alias_method :to_h, :to_hash
 
     def served_by_pages?
-      @served_by_pages ||= begin
+      if @served_by_pages.nil?
         response = Typhoeus.head(uri, TYPHOEUS_OPTIONS)
         # Workaround for webmock not playing nicely with Typhoeus redirects
         # See https://github.com/bblimke/webmock/issues/237
@@ -179,8 +179,9 @@ class GitHubPages
           response = Typhoeus.head(response.headers["Location"], TYPHOEUS_OPTIONS)
         end
 
-        (response.mock? || response.return_code == :ok) && response.headers["Server"] == "GitHub.com"
+        @served_by_pages = (response.mock? || response.return_code == :ok) && response.headers["Server"] == "GitHub.com"
       end
+      @served_by_pages
     end
 
     def to_json

--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -70,13 +70,19 @@ class GitHubPages
 
     # Returns an array of DNS answers
     def dns
-      @dns ||= Timeout::timeout(TIMEOUT) do
-        without_warnings do
-          Net::DNS::Resolver.start(absolute_domain).answer if domain
+      if @dns.nil?
+        begin
+          @dns = Timeout::timeout(TIMEOUT) do
+            without_warnings do
+              Net::DNS::Resolver.start(absolute_domain).answer if domain
+            end
+          end
+          @dns ||= false
+        rescue Exception
+          @dns = false
         end
       end
-    rescue Exception
-      nil
+      @dns || nil
     end
 
     # Are we even able to get the DNS record?


### PR DESCRIPTION
Ruby treats `nil` and `false` the same when they're on the left hand side of a `||=`. There are a couple of slow bits of code that are supposed to run once, but could run on each call, if they return `nil` or `false`. This branch changes them to be more explicit about how they handle their instance variables to ensure that the falsy results don't lead to a retry on the next call.

* `#dns` - This can be an array of results or `nil`. Before this branch, `@dns == nil` initially and if the dns results should be `nil`. This branch changes the latter case to set `@dns = false`, and it checks explicitly for `@dns.nil?` to know if it should actually look up any values.

* `#served_by_pages?` - This will return `true` or `false`. Before this branch, `@served_by_pages` would be `nil` on init and a boolean after the check had been run. The check ran any time `@served_by_pages` was `nil` or `false`. This branch changes it so that the check only runs when `@served_by_pages.nil?`.

cc @benbalter 