### PR TITLE
HealthCheck.new should accept domains and URI's

### DIFF
--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -47,7 +47,7 @@ class GitHubPages
     }
 
     def initialize(domain)
-      @domain = domain
+      @domain = host_from_uri(domain)
     end
 
     def cloudflare_ip?
@@ -259,6 +259,25 @@ class GitHubPages
 
     def uri
       @uri ||= Addressable::URI.new(:host => domain, :scheme => scheme, :path => "/").normalize
+    end
+
+    # Parse the URI. Accept either domain names or full URI's.
+    # Used by the initializer so we can be more flexible with inputs.
+    #
+    # domain - a URI or domain name.
+    #
+    # Examples
+    #
+    #   host_from_uri("benbalter.github.com")
+    #   # => 'benbalter.github.com'
+    #   host_from_uri("https://benbalter.github.com")
+    #   # => 'benbalter.github.com'
+    #   host_from_uri("benbalter.github.com/help-me-im-a-path/")
+    #   # => 'benbalter.github.com'
+    #
+    # Return the hostname.
+    def host_from_uri(domain)
+      Addressable::URI.parse(domain).host || Addressable::URI.parse("http://#{domain}").host
     end
   end
 end

--- a/script/cibuild
+++ b/script/cibuild
@@ -4,6 +4,6 @@ set -ex
 
 script/bootstrap
 
-bundle exec rspec
+script/test
 script/check-cloudflare-ips
 bundle exec gem build github-pages-health-check.gemspec

--- a/script/test
+++ b/script/test
@@ -1,0 +1,2 @@
+#!/bin/sh
+bundle exec rspec $@

--- a/spec/github_pages_health_check_spec.rb
+++ b/spec/github_pages_health_check_spec.rb
@@ -6,6 +6,30 @@ describe(GitHubPages::HealthCheck) do
     GitHubPages::HealthCheck.new(domain)
   end
 
+  context "constructor" do
+    let(:expected) { "foo.github.io" }
+    before(:each) do
+      stub_request(:head, expected).
+         to_return(:status => 200, :headers => {:server => "GitHub.com"})
+    end
+
+    it "can handle bare domains" do
+      expect(make_health_check("foo.github.io").domain).to eql(expected)
+    end
+
+    it "can handle URI's" do
+      expect(make_health_check("https://foo.github.io").domain).to eql(expected)
+      expect(make_health_check("http://foo.github.io").domain).to eql(expected)
+      expect(make_health_check("ftp://foo.github.io").domain).to eql(expected)
+    end
+
+    it "can handle paths" do
+      expect(make_health_check("foo.github.io/im-a-path/").domain).to eql(expected)
+      expect(make_health_check("foo.github.io/im-a-path").domain).to eql(expected)
+      expect(make_health_check("foo.github.io/index.html").domain).to eql(expected)
+    end
+  end
+
   def a_packet(ip)
      Net::DNS::RR::A.new(:name => "pages.invalid", :address => ip, :ttl => 1000)
   end


### PR DESCRIPTION
When we're trying to run a health check and we copy it from the address bar,
it often automatically has looks like `http://#{domain}/`. This change makes
the constructor more tolerant so this becomes less of a pain point.

/cc @github/pages