### PR TITLE
Check if domain is CNAME to pages.github.com or directly to Fastly

### DIFF
--- a/script/check
+++ b/script/check
@@ -8,4 +8,4 @@ if ARGV.count != 1
   exit 1
 end
 
-puts GitHubPages::HealthCheck.new(ARGV[0])
+puts GitHubPages::HealthCheck.check(ARGV[0])


### PR DESCRIPTION
This pull request expands the `InvalidCNAME` check to look for two additional conditions:

1. The domain is a CNAME, but the CNAME is to `page.github.com`, not `[username].github.io`

2. The domain is a CNAME, but the CNAME is to `github.map.fastly.net` directly, not to `[username].github.io`

In both cases, the misconfiguration makes it harder for us to prevent abuse at the DNS level.

To accomplish this, `Domain#cname` now returns a Domain object, rather than the CNAME string, allowing us to more easily run checks on the target domain (where the CNAME resolves to).

Fixes https://github.com/github/pages-health-check/issues/40.