### PR TITLE
Gracefully fallback for domains without CNAMEs

### DIFF
--- a/lib/github-pages-health-check/repository.rb
+++ b/lib/github-pages-health-check/repository.rb
@@ -5,7 +5,7 @@ module GitHubPages
       attr_reader :name, :owner
 
       REPO_REGEX = %r{\A[a-z0-9_\-]+/[a-z0-9_\-\.]+\z}i
-      
+
       HASH_METHODS = [
         :name_with_owner, :built?, :last_built,  :build_duration, :build_error
       ].freeze
@@ -39,7 +39,7 @@ module GitHubPages
       end
 
       def build_error
-        last_build.error.message unless built?
+        last_build.error["message"] unless built?
       end
       alias_method :reason, :build_error
 
@@ -52,6 +52,7 @@ module GitHubPages
       end
 
       def domain
+        return if cname.nil?
         @domain ||= GitHubPages::HealthCheck::Domain.new(cname)
       end
 

--- a/lib/github-pages-health-check/site.rb
+++ b/lib/github-pages-health-check/site.rb
@@ -13,13 +13,12 @@ module GitHubPages
       end
 
       def check!
-        domain.check!
-        repository.check! unless repository.nil?
+        [domain, repository].each { |check| check.check! unless check.nil? }
         true
       end
 
       def to_hash
-        hash = domain.to_hash.dup
+        hash = (domain || {}).to_hash.dup
         hash = hash.merge(repository.to_hash) unless repository.nil?
         hash[:valid?] = valid?
         hash[:reason] = reason

--- a/spec/fixtures/pages_info_no_cname.json
+++ b/spec/fixtures/pages_info_no_cname.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://api.github.com/repos/github/pages.github.com/pages",
+  "status": "built",
+  "cname": null,
+  "custom_404": false
+}

--- a/spec/github_pages_health_check_repository_spec.rb
+++ b/spec/github_pages_health_check_repository_spec.rb
@@ -102,7 +102,7 @@ describe(GitHubPages::HealthCheck::Repository) do
 
     context "without an access token" do
       before { subject.instance_variable_set("@access_token", nil) }
-      
+
       it "raises an error" do
         expected = GitHubPages::HealthCheck::Errors::MissingAccessTokenError
         expect { subject.send(:client) }.to raise_error(expected)
@@ -129,6 +129,19 @@ describe(GitHubPages::HealthCheck::Repository) do
     it "returns the domain" do
       expect(subject.domain.class).to eql(GitHubPages::HealthCheck::Domain)
       expect(subject.domain.host).to eql("pages.github.com")
+    end
+
+    context "without a CNAME" do
+      before do
+        subject.instance_variable_set("@access_token", "1234")
+        fixture = File.read(fixture_path("pages_info_no_cname.json"))
+        stub_request(:get, "https://api.github.com/repos/github/pages.github.com/pages").
+          to_return(:status => 200, :body => fixture, :headers => {'Content-Type'=>'application/json'})
+      end
+
+      it "doesn't try to build the domain" do
+        expect(subject.domain).to be_nil
+      end
     end
   end
 end

--- a/spec/github_pages_health_check_site_spec.rb
+++ b/spec/github_pages_health_check_site_spec.rb
@@ -50,6 +50,30 @@ describe(GitHubPages::HealthCheck::Site) do
         end
       end
 
+      context "with no cname" do
+        before do
+          if init_type == "repo"
+            fixture = File.read(fixture_path("pages_info_no_cname.json"))
+            stub_request(:get, "https://api.github.com/repos/github/pages.github.com/pages").
+              to_return(:status => 200, :body => fixture, :headers => {'Content-Type'=>'application/json'})
+
+            fixture = File.read(fixture_path("build_success.json"))
+            stub_request(:get, "https://api.github.com/repos/github/pages.github.com/pages/builds/latest").
+                to_return(:status => 200, :body => fixture, :headers => {'Content-Type'=>'application/json'})
+          end
+        end
+
+        if init_type == "repo"
+          it "knows it doesn't know the domain" do
+            expect(subject.domain).to eql(nil)
+          end
+
+          it "doesnt err out when it checks" do
+            expect(subject.check!).to eql(true)
+          end
+        end
+      end
+
       context "json" do
         let(:json) { JSON.parse subject.to_json }
 


### PR DESCRIPTION
This simply guards against undefined method for NilClass errors when Domain is nil (and tests against it).

Fixes #42
