### PR TITLE
Call to_s on the reason field before converting to a hash

### DIFF
--- a/lib/github-pages-health-check/printer.rb
+++ b/lib/github-pages-health-check/printer.rb
@@ -12,7 +12,9 @@ module GitHubPages
 
       def simple_string
         require 'yaml'
-        health_check.to_hash.to_yaml.sub(/\A---\n/, "").gsub(/^:/, "")
+        hash = health_check.to_hash
+        hash[:reason] = hash[:reason].to_s if hash[:reason]
+        hash.to_yaml.sub(/\A---\n/, "").gsub(/^:/, "")
       end
 
       def pretty_print


### PR DESCRIPTION
This prevents YAML from outputting ugliness like this:

```yml
reason: !ruby/exception:GitHubPages::HealthCheck::Errors::BuildError
  message: The tag `blah` in `index.html` is not a recognized Liquid tag. For more
    information, see https://help.github.com/articles/page-build-failed-unknown-tag-error.
```