### PR TITLE
Reduce DNS timeout to 5 seconds

### DIFF
--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -29,7 +29,7 @@ module GitHubPages
     autoload :Printer,    "github-pages-health-check/printer"
 
     # DNS and HTTP timeout, in seconds
-    TIMEOUT = 10
+    TIMEOUT = 5
 
     TYPHOEUS_OPTIONS = {
       :followlocation  => true,


### PR DESCRIPTION
That should be more than enough for most domains, and will speed things up for domains that don't resolve.