### PR TITLE
Use valid_domain? as an early escape hatch

### DIFF
--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -34,8 +34,8 @@ module GitHubPages
 
       # Runs all checks, raises an error if invalid
       def check!
-        return unless valid_domain?
-        raise Errors::InvalidDNSError unless dns_resolves?
+        raise Errors::InvalidDomainError unless valid_domain?
+        raise Errors::InvalidDNSError    unless dns_resolves?
         return true if proxied?
         raise Errors::DeprecatedIPError      if deprecated_ip?
         raise Errors::InvalidARecordError    if invalid_a_record?

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -204,7 +204,6 @@ module GitHubPages
         return unless dns_resolves?
 
         @served_by_pages = begin
-
           response = Typhoeus.head(uri, TYPHOEUS_OPTIONS)
 
           # Workaround for webmock not playing nicely with Typhoeus redirects

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -76,9 +76,14 @@ module GitHubPages
         return @apex_domain if defined?(@apex_domain)
         return unless valid_domain?
 
-        answers = Resolv::DNS.open { |dns|
-          dns.getresources(absolute_domain, Resolv::DNS::Resource::IN::NS)
-        }
+          answers = begin
+            Resolv::DNS.open { |dns|
+              dns.timeouts = TIMEOUT
+              dns.getresources(absolute_domain, Resolv::DNS::Resource::IN::NS)
+            }
+          rescue Timeout::Error, NoMethodError
+            []
+          end
 
         @apex_domain = answers.any?
       end

--- a/spec/github_pages_health_check_domain_spec.rb
+++ b/spec/github_pages_health_check_domain_spec.rb
@@ -404,6 +404,9 @@ describe(GitHubPages::HealthCheck::Domain) do
 
       domain_check = make_domain_check "github.invalid"
       expect(domain_check.valid_domain?).to be(false)
+      
+      expect(domain_check.reason.class).to eql(GitHubPages::HealthCheck::Errors::InvalidDomainError)
+      expect(domain_check.reason.message).to eql("Domain is not a valid domain")
     end
   end
 


### PR DESCRIPTION
This pull request places an `unless valid_domain?` escape hatch before any network call to reduce the likelihood that the Gem will waste time trying to resolve a obviously unresolvable domain (e.g., `foo.invalid`).

This will be a *slight* change in behavior and a *slight* change in philosophy. 

Currently, the behavior is to return all the information we can about a given domain, even it's invalid, and only used `valid_domain?` to guard against false positives.

If merged, this pull request will change that behavior, such that the gem will return **minimal** information for invalid domains, but will never raise an error.

The idea here, is some domains are valid, but not represented in public suffix. Rather than raise a false positive for one of these edge case domains, return a potential false negative, and bail early for any non-public-suffix recognized domain, which in the vast majority of cases, will speed up checks, as we're not going to be trying to resolve or request a domain we have good reason to believe isn't actually there. 