### PR TITLE
Better domain normalization

### DIFF
--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -29,7 +29,7 @@ module GitHubPages
           raise ArgumentError, "Expected string, got #{host.class}"
         end
 
-        @host = host_from_uri(host)
+        @host = normalize_host(host)
       end
 
       # Runs all checks, raises an error if invalid
@@ -241,15 +241,16 @@ module GitHubPages
       #
       # Examples
       #
-      #   host_from_uri("benbalter.github.com")
+      #   normalize_host("benbalter.github.com")
       #   # => 'benbalter.github.com'
-      #   host_from_uri("https://benbalter.github.com")
+      #   normalize_host("https://benbalter.github.com")
       #   # => 'benbalter.github.com'
-      #   host_from_uri("benbalter.github.com/help-me-im-a-path/")
+      #   normalize_host("benbalter.github.com/help-me-im-a-path/")
       #   # => 'benbalter.github.com'
       #
       # Return the hostname.
-      def host_from_uri(domain)
+      def normalize_host(domain)
+        domain = domain.strip.chomp(".")
         Addressable::URI.parse(domain).host || Addressable::URI.parse("http://#{domain}").host
       end
 

--- a/spec/github_pages_health_check_domain_spec.rb
+++ b/spec/github_pages_health_check_domain_spec.rb
@@ -31,6 +31,14 @@ describe(GitHubPages::HealthCheck::Domain) do
       expect(make_domain_check("foo.github.io/im-a-path").host).to eql(expected)
       expect(make_domain_check("foo.github.io/index.html").host).to eql(expected)
     end
+
+    it "strips whitespace" do
+      expect(make_domain_check(" foo.github.io ").host).to eql(expected)
+    end
+
+    it "normalizes FQDNs" do
+      expect(make_domain_check("foo.github.io.").host).to eql(expected)
+    end
   end
 
   context "A records" do
@@ -404,7 +412,7 @@ describe(GitHubPages::HealthCheck::Domain) do
 
       domain_check = make_domain_check "github.invalid"
       expect(domain_check.valid_domain?).to be(false)
-      
+
       expect(domain_check.reason.class).to eql(GitHubPages::HealthCheck::Errors::InvalidDomainError)
       expect(domain_check.reason.message).to eql("Domain is not a valid domain")
     end


### PR DESCRIPTION
This prevents the health check from erring out on domains with whitespace and FQDNs with trailing periods.

In doing so, this rename the private `host_from_uri` to `normalize_host`.