### PR TITLE
Empty hosts are also invalid

### DIFF
--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -251,8 +251,8 @@ module GitHubPages
       # Return the hostname.
       def normalize_host(domain)
         domain = domain.strip.chomp(".")
-        domain = Addressable::URI.parse(domain).host || Addressable::URI.parse("http://#{domain}").host
-        domain unless domain.to_s.empty?
+        host = Addressable::URI.parse(domain).host || Addressable::URI.parse("http://#{domain}").host
+        host unless host.to_s.empty?
       rescue Addressable::URI::InvalidURIError
         nil
       end

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -251,7 +251,8 @@ module GitHubPages
       # Return the hostname.
       def normalize_host(domain)
         domain = domain.strip.chomp(".")
-        Addressable::URI.parse(domain).host || Addressable::URI.parse("http://#{domain}").host
+        domain = Addressable::URI.parse(domain).host || Addressable::URI.parse("http://#{domain}").host
+        domain unless domain.to_s.empty?
       rescue Addressable::URI::InvalidURIError
         nil
       end

--- a/spec/github_pages_health_check_domain_spec.rb
+++ b/spec/github_pages_health_check_domain_spec.rb
@@ -44,6 +44,10 @@ describe(GitHubPages::HealthCheck::Domain) do
       check = make_domain_check("http://@")
       expect(check.host).to eql(nil)
       expect(check.reason.class).to eql(GitHubPages::HealthCheck::Errors::InvalidDomainError)
+
+      check = make_domain_check("//")
+      expect(check.host).to eql(nil)
+      expect(check.reason.class).to eql(GitHubPages::HealthCheck::Errors::InvalidDomainError)
     end
   end
 


### PR DESCRIPTION
So `normalize_domain` should return `nil`, not an empty string.

This prevents undefined method errors down the line, since `domain_valid?` is already an early escape hatch.