### PR TITLE
Better human-readable error messages 

### DIFF
--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -34,13 +34,13 @@ module GitHubPages
 
       # Runs all checks, raises an error if invalid
       def check!
-        raise Errors::InvalidDomainError unless valid_domain?
-        raise Errors::InvalidDNSError    unless dns_resolves?
+        raise Errors::InvalidDomainError.new(domain: self) unless valid_domain?
+        raise Errors::InvalidDNSError.new(domain: self)    unless dns_resolves?
         return true if proxied?
-        raise Errors::DeprecatedIPError      if deprecated_ip?
-        raise Errors::InvalidARecordError    if invalid_a_record?
-        raise Errors::InvalidCNAMEError      if invalid_cname?
-        raise Errors::NotServedByPagesError  unless served_by_pages?
+        raise Errors::DeprecatedIPError.new(domain: self)      if deprecated_ip?
+        raise Errors::InvalidARecordError.new(domain: self)    if invalid_a_record?
+        raise Errors::InvalidCNAMEError.new(domain: self)      if invalid_cname?
+        raise Errors::NotServedByPagesError.new(domain: self)  unless served_by_pages?
         true
       end
 

--- a/lib/github-pages-health-check/error.rb
+++ b/lib/github-pages-health-check/error.rb
@@ -25,10 +25,11 @@ module GitHubPages
         "Something's wrong with your GitHub Pages site."
       end
 
+      # Error message, with get more info URL appended
       def message_with_url
         msg = message.gsub(/\s+/, " ").squeeze(" ").strip
-        msg << "." unless msg =~ /\.$/
-        [msg, more_info].join(" ")
+        msg << "." unless msg =~ /\.$/ #add trailing period if not there
+        "#{msg} #{more_info}"
       end
       alias_method :message_formatted, :message_with_url
 

--- a/lib/github-pages-health-check/error.rb
+++ b/lib/github-pages-health-check/error.rb
@@ -3,6 +3,7 @@ module GitHubPages
     class Error < StandardError
       DOCUMENTATION_BASE = "https://help.github.com"
       DOCUMENTATION_PATH = "/categories/github-pages-basics/"
+      LOCAL_ONLY = false # Error is only used when running locally
 
       attr_reader :repository, :domain
 

--- a/lib/github-pages-health-check/error.rb
+++ b/lib/github-pages-health-check/error.rb
@@ -2,6 +2,7 @@ module GitHubPages
   module HealthCheck
     class Error < StandardError
       DOCUMENTATION_BASE = "https://help.github.com"
+      DOCUMENTATION_PATH = "/categories/github-pages-basics/"
 
       attr_reader :repository, :domain
 
@@ -19,9 +20,16 @@ module GitHubPages
         @subclasses ||= []
       end
 
-      def message_formatted
-        "#{message.gsub(/\s+/, " ").strip} #{more_info}"
+      def message
+        "Something's wrong with your GitHub Pages site."
       end
+
+      def message_with_url
+        msg = message.gsub(/\s+/, " ").squeeze(" ").strip
+        msg << "." unless msg =~ /\.$/
+        [msg, more_info].join(" ")
+      end
+      alias_method :message_formatted, :message_with_url
 
       private
 

--- a/lib/github-pages-health-check/error.rb
+++ b/lib/github-pages-health-check/error.rb
@@ -1,12 +1,44 @@
 module GitHubPages
   module HealthCheck
     class Error < StandardError
+      DOCUMENTATION_BASE = "https://help.github.com"
+
+      attr_reader :repository, :domain
+
+      def initialize(repository: nil, domain: nil)
+        super
+        @repository = repository
+        @domain     = domain
+      end
+
       def self.inherited(base)
         subclasses << base
       end
 
       def self.subclasses
         @subclasses ||= []
+      end
+
+      def message_formatted
+        "#{message.gsub(/\s+/, " ").strip} #{more_info}"
+      end
+
+      private
+
+      def username
+        if repository.nil?
+          "[YOUR USERNAME]"
+        else
+          repository.owner
+        end
+      end
+
+      def more_info
+        "For more information, see #{documentation_url}."
+      end
+
+      def documentation_url
+        URI.join(Error::DOCUMENTATION_BASE, self.class::DOCUMENTATION_PATH).to_s
       end
     end
   end

--- a/lib/github-pages-health-check/errors/build_error.rb
+++ b/lib/github-pages-health-check/errors/build_error.rb
@@ -3,6 +3,7 @@ module GitHubPages
     module Errors
       class BuildError < GitHubPages::HealthCheck::Error
         DOCUMENTATION_PATH = '/articles/troubleshooting-jekyll-builds/'
+        LOCAL_ONLY = true
       end
     end
   end

--- a/lib/github-pages-health-check/errors/build_error.rb
+++ b/lib/github-pages-health-check/errors/build_error.rb
@@ -2,6 +2,7 @@ module GitHubPages
   module HealthCheck
     module Errors
       class BuildError < GitHubPages::HealthCheck::Error
+        DOCUMENTATION_PATH = '/articles/troubleshooting-jekyll-builds/'
       end
     end
   end

--- a/lib/github-pages-health-check/errors/deprecated_ip_error.rb
+++ b/lib/github-pages-health-check/errors/deprecated_ip_error.rb
@@ -2,7 +2,7 @@ module GitHubPages
   module HealthCheck
     module Errors
       class DeprecatedIPError < GitHubPages::HealthCheck::Error
-        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages".freeze
+        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages/".freeze
 
         def message
           <<-MSG

--- a/lib/github-pages-health-check/errors/deprecated_ip_error.rb
+++ b/lib/github-pages-health-check/errors/deprecated_ip_error.rb
@@ -2,8 +2,13 @@ module GitHubPages
   module HealthCheck
     module Errors
       class DeprecatedIPError < GitHubPages::HealthCheck::Error
+        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages".freeze
+
         def message
-          "A record points to deprecated IP address"
+          <<-MSG
+            The custom domain for your GitHub Pages site is pointed at an outdated IP address.
+            You must update your site's DNS records if you'd like it to be available via your custom domain.
+           MSG
         end
       end
     end

--- a/lib/github-pages-health-check/errors/invalid_a_record_error.rb
+++ b/lib/github-pages-health-check/errors/invalid_a_record_error.rb
@@ -2,8 +2,15 @@ module GitHubPages
   module HealthCheck
     module Errors
       class InvalidARecordError < GitHubPages::HealthCheck::Error
+        # rubocop:disable Metrics/LineLength
+        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages/".freeze
+
         def message
-          "Should not be an A record"
+          <<-MSG
+             Your site's DNS settings are using a custom subdomain, #{domain.host},
+             that's set up as an A record. We recommend you change this to a CNAME
+             record pointing at #{username}.github.io.
+           MSG
         end
       end
     end

--- a/lib/github-pages-health-check/errors/invalid_cname_error.rb
+++ b/lib/github-pages-health-check/errors/invalid_cname_error.rb
@@ -2,8 +2,15 @@ module GitHubPages
   module HealthCheck
     module Errors
       class InvalidCNAMEError < GitHubPages::HealthCheck::Error
+        # rubocop:disable Metrics/LineLength
+        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages/".freeze
+
         def message
-          "CNAME does not point to GitHub Pages"
+          <<-MSG
+             Your site's DNS settings are using a custom subdomain, #{domain.host},
+             that's not set up with a correct CNAME record.  We recommend you set this
+             CNAME record to point at #{username}.github.io.
+           MSG
         end
       end
     end

--- a/lib/github-pages-health-check/errors/invalid_dns_error.rb
+++ b/lib/github-pages-health-check/errors/invalid_dns_error.rb
@@ -2,6 +2,9 @@ module GitHubPages
   module HealthCheck
     module Errors
       class InvalidDNSError < GitHubPages::HealthCheck::Error
+        # rubocop:disable Metrics/LineLength
+        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages/".freeze
+
         def message
           "Domain's DNS record could not be retrieved"
         end

--- a/lib/github-pages-health-check/errors/invalid_domain_error.rb
+++ b/lib/github-pages-health-check/errors/invalid_domain_error.rb
@@ -2,6 +2,8 @@ module GitHubPages
   module HealthCheck
     module Errors
       class InvalidDomainError < GitHubPages::HealthCheck::Error
+        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages/".freeze
+
         def message
           "Domain is not a valid domain"
         end

--- a/lib/github-pages-health-check/errors/invalid_repository_error.rb
+++ b/lib/github-pages-health-check/errors/invalid_repository_error.rb
@@ -2,6 +2,7 @@ module GitHubPages
   module HealthCheck
     module Errors
       class InvalidRepositoryError < GitHubPages::HealthCheck::Error
+        LOCAL_ONLY = true
         def message
           "Repository is not a valid repository"
         end

--- a/lib/github-pages-health-check/errors/missing_access_token_error.rb
+++ b/lib/github-pages-health-check/errors/missing_access_token_error.rb
@@ -2,6 +2,7 @@ module GitHubPages
   module HealthCheck
     module Errors
       class MissingAccessTokenError < GitHubPages::HealthCheck::Error
+        LOCAL_ONLY = true
         def message
           "Cannot retrieve repository information with a valid access token"
         end

--- a/lib/github-pages-health-check/errors/not_served_by_pages_error.rb
+++ b/lib/github-pages-health-check/errors/not_served_by_pages_error.rb
@@ -2,6 +2,8 @@ module GitHubPages
   module HealthCheck
     module Errors
       class NotServedByPagesError < GitHubPages::HealthCheck::Error
+        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages/".freeze
+
         def message
           "Domain does not resolve to the GitHub Pages server"
         end

--- a/lib/github-pages-health-check/repository.rb
+++ b/lib/github-pages-health-check/repository.rb
@@ -26,7 +26,7 @@ module GitHubPages
       alias_method :nwo, :name_with_owner
 
       def check!
-        raise Errors::BuildError, build_error unless built?
+        raise Errors::BuildError.new(repository: self), build_error unless built?
         true
       end
 

--- a/spec/github_pages_health_check_domain_spec.rb
+++ b/spec/github_pages_health_check_domain_spec.rb
@@ -346,7 +346,7 @@ describe(GitHubPages::HealthCheck::Domain) do
       check = make_domain_check "developers.facebook.com"
       expect(check.valid?).to eql(false)
       expect(check.reason.class).to eql(GitHubPages::HealthCheck::Errors::InvalidCNAMEError)
-      expect(check.reason.message).to eql("CNAME does not point to GitHub Pages")
+      expect(check.reason.message).to match(/not set up with a correct CNAME record/i)
     end
   end
 

--- a/spec/github_pages_health_check_error_spec.rb
+++ b/spec/github_pages_health_check_error_spec.rb
@@ -4,7 +4,7 @@ describe(GitHubPages::HealthCheck::Error) do
 
   GitHubPages::HealthCheck::Errors.all.each do |klass|
     next if klass::LOCAL_ONLY
-    
+
     context "The #{klass.name.split('::').last} error" do
       let(:domain) { GitHubPages::HealthCheck::Domain.new("example.com") }
       subject { klass.new(domain: domain) }
@@ -19,6 +19,10 @@ describe(GitHubPages::HealthCheck::Error) do
         default = "/categories/github-pages-basics/"
         expect(klass::DOCUMENTATION_PATH).to_not eql(default)
         expect(subject.send(:documentation_url)).to_not be_nil
+      end
+
+      it "the documentation path has a trailing slash" do
+        expect(klass::DOCUMENTATION_PATH).to match(%r{/$})
       end
     end
   end

--- a/spec/github_pages_health_check_error_spec.rb
+++ b/spec/github_pages_health_check_error_spec.rb
@@ -1,15 +1,10 @@
 require "spec_helper"
 
 describe(GitHubPages::HealthCheck::Error) do
-  # Errors used locally that do not have coresponding documentation URLs
-  ERROR_WHITELIST = [
-    GitHubPages::HealthCheck::Errors::MissingAccessTokenError,
-    GitHubPages::HealthCheck::Errors::InvalidRepositoryError
-  ]
 
   GitHubPages::HealthCheck::Errors.all.each do |klass|
-    next if ERROR_WHITELIST.include?(klass)
-
+    next if klass::LOCAL_ONLY
+    
     context "The #{klass.name.split('::').last} error" do
       let(:domain) { GitHubPages::HealthCheck::Domain.new("example.com") }
       subject { klass.new(domain: domain) }

--- a/spec/github_pages_health_check_error_spec.rb
+++ b/spec/github_pages_health_check_error_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+
+describe(GitHubPages::HealthCheck::Error) do
+  # Errors used locally that do not have coresponding documentation URLs
+  ERROR_WHITELIST = [
+    GitHubPages::HealthCheck::Errors::MissingAccessTokenError,
+    GitHubPages::HealthCheck::Errors::InvalidRepositoryError
+  ]
+
+  GitHubPages::HealthCheck::Errors.all.each do |klass|
+    next if ERROR_WHITELIST.include?(klass)
+
+    context "The #{klass.name.split('::').last} error" do
+      let(:domain) { GitHubPages::HealthCheck::Domain.new("example.com") }
+      subject { klass.new(domain: domain) }
+
+      it "has a message" do
+        expect(subject.message).to_not be_empty
+      end
+
+      it "has a documentation url" do
+        expect(klass::DOCUMENTATION_PATH).to_not be_nil
+        expect(klass::DOCUMENTATION_PATH).to_not be_empty
+        default = "/categories/github-pages-basics/"
+        expect(klass::DOCUMENTATION_PATH).to_not eql(default)
+        expect(subject.send(:documentation_url)).to_not be_nil
+      end
+    end
+  end
+
+  context "with a repository" do
+    let(:nwo) { "github/pages.github.com" }
+    let(:repo) { GitHubPages::HealthCheck::Repository.new(nwo) }
+    subject { described_class.new(repository: repo) }
+
+    it "knows the username" do
+      expect(subject.send(:username)).to eql("github")
+    end
+  end
+
+  context "without a repository" do
+    it "has a placeholder username" do
+      expect(subject.send(:username)).to eql("[YOUR USERNAME]")
+    end
+  end
+
+  it "builds the documentation URL" do
+    url = "https://help.github.com/categories/github-pages-basics/"
+    expect(subject.send(:documentation_url)).to eql(url)
+  end
+
+  it "builds the more info string" do
+    msg = "For more information, "
+    msg << "see https://help.github.com/categories/github-pages-basics/."
+    expect(subject.send(:more_info)).to eql(msg)
+  end
+
+  it "returns the message with URL" do
+    msg = "Something's wrong with your GitHub Pages site. "
+    msg << "For more information, "
+    msg << "see https://help.github.com/categories/github-pages-basics/."
+    expect(subject.message_with_url).to eql(msg)
+  end
+end

--- a/spec/github_pages_health_check_errors_spec.rb
+++ b/spec/github_pages_health_check_errors_spec.rb
@@ -4,4 +4,29 @@ describe(GitHubPages::HealthCheck::Errors) do
   it "returns the errors" do
     expect(GitHubPages::HealthCheck::Errors.all.count).to eql(9)
   end
+
+  # Errors used locally that do not have coresponding documentation URLs
+  ERROR_WHITELIST = [
+    GitHubPages::HealthCheck::Errors::MissingAccessTokenError,
+    GitHubPages::HealthCheck::Errors::InvalidRepositoryError
+  ]
+
+  GitHubPages::HealthCheck::Errors.all.each do |klass|
+    next if ERROR_WHITELIST.include?(klass)
+    
+    context "The #{klass.name.split('::').last} error" do
+      let(:domain) { GitHubPages::HealthCheck::Domain.new("example.com") }
+      subject { klass.new(domain: domain) }
+
+      it "has a message" do
+        expect(subject.message).to_not be_empty
+      end
+
+      it "has a documentation url" do
+        expect(klass::DOCUMENTATION_PATH).to_not be_nil
+        expect(klass::DOCUMENTATION_PATH).to_not be_empty
+        expect(subject.send(:documentation_url)).to_not be_nil
+      end
+    end
+  end
 end

--- a/spec/github_pages_health_check_errors_spec.rb
+++ b/spec/github_pages_health_check_errors_spec.rb
@@ -4,29 +4,4 @@ describe(GitHubPages::HealthCheck::Errors) do
   it "returns the errors" do
     expect(GitHubPages::HealthCheck::Errors.all.count).to eql(9)
   end
-
-  # Errors used locally that do not have coresponding documentation URLs
-  ERROR_WHITELIST = [
-    GitHubPages::HealthCheck::Errors::MissingAccessTokenError,
-    GitHubPages::HealthCheck::Errors::InvalidRepositoryError
-  ]
-
-  GitHubPages::HealthCheck::Errors.all.each do |klass|
-    next if ERROR_WHITELIST.include?(klass)
-    
-    context "The #{klass.name.split('::').last} error" do
-      let(:domain) { GitHubPages::HealthCheck::Domain.new("example.com") }
-      subject { klass.new(domain: domain) }
-
-      it "has a message" do
-        expect(subject.message).to_not be_empty
-      end
-
-      it "has a documentation url" do
-        expect(klass::DOCUMENTATION_PATH).to_not be_nil
-        expect(klass::DOCUMENTATION_PATH).to_not be_empty
-        expect(subject.send(:documentation_url)).to_not be_nil
-      end
-    end
-  end
 end


### PR DESCRIPTION
This pull request is intended to move the more descriptive human-readable error messages that GitHub Pages uses into the open source Ruby gem, where they can be shared between implementations. Specifically, errors, as exposed via `HealthCheck#reason` have an expanded `#message` method, and also expose `#message_with_url` which would provide a URL to the help docs.

The code's definitely a bit rough and could use some :eyes:.
