### PR TITLE
Fix output of reason when pretty printing

### DIFF
--- a/lib/github-pages-health-check/error.rb
+++ b/lib/github-pages-health-check/error.rb
@@ -33,6 +33,10 @@ module GitHubPages
       end
       alias_method :message_formatted, :message_with_url
 
+      def to_s
+        "#{message_with_url} (#{self.class.name.split('::').last})".gsub("\n", " ").squeeze(" ").strip
+      end
+
       private
 
       def username


### PR DESCRIPTION
Right now, reason is outputted as the class's default `to_s`, when called via e.g., `script/check` or `check.to_s`. 

This adds an explicit `to_s` method that includes the message and error class.