### PR TITLE
Upgrade PublicSuffix to v2

### DIFF
--- a/github-pages-health-check.gemspec
+++ b/github-pages-health-check.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths         = ['lib']
 
   s.add_dependency("net-dns", "~> 0.8")
-  s.add_dependency("public_suffix", "~> 1.4")
+  s.add_dependency("public_suffix", "~> 2.0")
   s.add_dependency("typhoeus", "~> 0.7")
   s.add_dependency("addressable", "~> 2.3")
   s.add_dependency("octokit", "~> 4.0")

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -72,7 +72,7 @@ module GitHubPages
       # Used as an escape hatch to prevent false positives on DNS checkes
       def valid_domain?
         return @valid if defined? @valid
-        @valid = PublicSuffix.valid?(host)
+        @valid = PublicSuffix.valid?(host, default_rule: nil)
       end
 
       # Is this domain an apex domain, meaning a CNAME would be innapropriate


### PR DESCRIPTION
This PR upgrades the `public_suffix` gem to v2.0.

We only hit one snafu:

> Now that the library is 100% compliant with the official PublicSuffix algorithm, if a domain passed as input doesn't match any rule, the wildcard rule `*` is assumed. This means that unlisted TLDs will be considered valid by default, when they would have been invalid in 1.x. However, you can override this behavior to emulate the 1.x behavior if needed.

Upgrading documentation is here: https://github.com/weppos/publicsuffix-ruby/blob/v2.0.3/2.0-Upgrade.md

/cc @github/pages for review.