### PR TITLE
Domain#should_be_a_record?: also check for existence of MX records

### DIFF
--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -21,7 +21,7 @@ module GitHubPages
 
       HASH_METHODS = [
         :host, :uri, :dns_resolves?, :proxied?, :cloudflare_ip?, :fastly_ip?,
-        :old_ip_address?, :a_record?, :cname_record?, :has_mx_records?,
+        :old_ip_address?, :a_record?, :cname_record?, :mx_records_present?,
         :valid_domain?, :apex_domain?, :should_be_a_record?,
         :cname_to_github_user_domain?, :cname_to_pages_dot_github_dot_com?,
         :cname_to_fastly?, :pointed_to_github_pages_ip?, :pages_domain?,
@@ -94,7 +94,7 @@ module GitHubPages
 
       # Should the domain be an apex record?
       def should_be_a_record?
-        !pages_domain? && (apex_domain? || has_mx_records?)
+        !pages_domain? && (apex_domain? || mx_records_present?)
       end
 
       def should_be_cname_record?
@@ -218,9 +218,9 @@ module GitHubPages
         @cname ||= Domain.new(dns.first.cname.to_s)
       end
 
-      def has_mx_records?
+      def mx_records_present?
         return unless dns?
-        dns.any? { |answer| p answer; answer.class == Net::DNS::RR::MX }
+        dns.any? { |answer| answer.class == Net::DNS::RR::MX }
       end
 
       def served_by_pages?

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -175,7 +175,6 @@ module GitHubPages
         @dns = Timeout.timeout(TIMEOUT) do
           GitHubPages::HealthCheck.without_warnings do
             unless host.nil?
-              resolver = Net::DNS::Resolver.new
               resolver.search(absolute_domain, Net::DNS::A).answer +
                 resolver.search(absolute_domain, Net::DNS::MX).answer
             end
@@ -183,6 +182,10 @@ module GitHubPages
         end
       rescue StandardError
         @dns = nil
+      end
+
+      def resolver
+        @resolver ||= Net::DNS::Resolver.new
       end
 
       # Are we even able to get the DNS record?

--- a/spec/github_pages_health_check_domain_spec.rb
+++ b/spec/github_pages_health_check_domain_spec.rb
@@ -350,11 +350,12 @@ describe(GitHubPages::HealthCheck::Domain) do
     end
 
     it "returns the error" do
-      stub_request(:head, "http://developers.facebook.com").to_return(:status => 200, :headers => {})
-      check = make_domain_check "developers.facebook.com"
+      stub_request(:head, "http://techblog.netflix.com").to_return(:status => 200, :headers => {})
+      check = make_domain_check "techblog.netflix.com"
       expect(check.valid?).to eql(false)
-      expect(check.reason.class).to eql(GitHubPages::HealthCheck::Errors::NotServedByPagesError)
-      expect(check.reason.message).to eql("Domain does not resolve to the GitHub Pages server")
+      expect(check.mx_records_present?).to eq(false)
+      expect(check.reason.class).to eql(GitHubPages::HealthCheck::Errors::InvalidCNAMEError)
+      expect(check.reason.message).to match(/not set up with a correct CNAME record/i)
     end
   end
 

--- a/spec/github_pages_health_check_domain_spec.rb
+++ b/spec/github_pages_health_check_domain_spec.rb
@@ -13,6 +13,10 @@ describe(GitHubPages::HealthCheck::Domain) do
     Net::DNS::RR::CNAME.new(:name => "pages.invalid", :cname => domain, :ttl => 1000)
   end
 
+  def mx_packet
+    Net::DNS::RR::MX.new(:name => "pages.invalid", :exchange => "mail.example.com", :preference => 10, :ttl => 100)
+  end
+
   context "constructor" do
     let(:expected) { "foo.github.io" }
 
@@ -123,6 +127,10 @@ describe(GitHubPages::HealthCheck::Domain) do
 
       domain_check = make_domain_check("pages.github.com")
       expect(domain_check.should_be_a_record?).to be(false)
+
+      domain_check = make_domain_check("blog.parkermoore.de")
+      allow(domain_check).to receive(:dns) { [a_packet("1.2.3.4"), mx_packet] }
+      expect(domain_check.should_be_a_record?).to be(true)
     end
 
     it "can determine a valid GitHub Pages CNAME value" do
@@ -345,8 +353,8 @@ describe(GitHubPages::HealthCheck::Domain) do
       stub_request(:head, "http://developers.facebook.com").to_return(:status => 200, :headers => {})
       check = make_domain_check "developers.facebook.com"
       expect(check.valid?).to eql(false)
-      expect(check.reason.class).to eql(GitHubPages::HealthCheck::Errors::InvalidCNAMEError)
-      expect(check.reason.message).to match(/not set up with a correct CNAME record/i)
+      expect(check.reason.class).to eql(GitHubPages::HealthCheck::Errors::NotServedByPagesError)
+      expect(check.reason.message).to eql("Domain does not resolve to the GitHub Pages server")
     end
   end
 


### PR DESCRIPTION
When a domain has MX records, it cannot be a CNAME. Therefore, if my subdomain, e.g. foo.example.com, has MX records, the health checker should ensure it is an A record pointing to the GHP servers.

/cc @github/pages for review.

Fixes #56.