### PR TITLE
Domain#cname? should return false if the value of the CNAME is bad

### DIFF
--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -28,6 +28,10 @@ module GitHubPages
         :valid_domain?
       ].freeze
 
+      def self.valid_domain?(domain)
+        !new(domain.to_s).host.nil?
+      end
+
       def initialize(host)
         unless host.is_a? String
           raise ArgumentError, "Expected string, got #{host.class}"
@@ -199,7 +203,8 @@ module GitHubPages
       # Is this domain's first response a CNAME record?
       def cname_record?
         return unless dns?
-        dns.first.class == Net::DNS::RR::CNAME
+        dns.first.class == Net::DNS::RR::CNAME &&
+          Domain.valid_domain?(dns.first.cname.to_s)
       end
       alias cname? cname_record?
 

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -28,10 +28,6 @@ module GitHubPages
         :valid_domain?
       ].freeze
 
-      def self.valid_domain?(domain)
-        !new(domain.to_s).host.nil?
-      end
-
       def initialize(host)
         unless host.is_a? String
           raise ArgumentError, "Expected string, got #{host.class}"
@@ -203,15 +199,15 @@ module GitHubPages
       # Is this domain's first response a CNAME record?
       def cname_record?
         return unless dns?
-        dns.first.class == Net::DNS::RR::CNAME &&
-          Domain.valid_domain?(dns.first.cname.to_s)
+        return false unless cname
+        cname.valid_domain?
       end
       alias cname? cname_record?
 
       # The domain to which this domain's CNAME resolves
       # Returns nil if the domain is not a CNAME
       def cname
-        return unless cname?
+        return unless dns.first.class == Net::DNS::RR::CNAME
         @cname ||= Domain.new(dns.first.cname.to_s)
       end
 

--- a/spec/github_pages_health_check_domain_spec.rb
+++ b/spec/github_pages_health_check_domain_spec.rb
@@ -91,6 +91,15 @@ describe(GitHubPages::HealthCheck::Domain) do
       expect(domain_check.a_record?).to be(false)
     end
 
+    it "handles a broken CNAME gracefully" do
+      domain_check = make_domain_check
+      allow(domain_check).to receive(:dns) do
+        [cname_packet("example.com").tap {|c| c.instance_variable_set(:@cname, "@.") }]
+      end
+      expect(domain_check.cname?).to be(false)
+      expect(described_class.valid_domain?("@.")).to be(false)
+    end
+
     it "returns the cname" do
       domain_check = make_domain_check
       allow(domain_check).to receive(:dns) { [cname_packet("pages.github.com")] }

--- a/spec/github_pages_health_check_domain_spec.rb
+++ b/spec/github_pages_health_check_domain_spec.rb
@@ -97,7 +97,7 @@ describe(GitHubPages::HealthCheck::Domain) do
         [cname_packet("example.com").tap {|c| c.instance_variable_set(:@cname, "@.") }]
       end
       expect(domain_check.cname?).to be(false)
-      expect(described_class.valid_domain?("@.")).to be(false)
+      expect(domain_check.cname.valid_domain?).to be(false)
     end
 
     it "returns the cname" do


### PR DESCRIPTION
If you do a `dig` and you get:

```text
;; QUESTION SECTION:
;sub.example.com.        IN    A

;; ANSWER SECTION:
sub.example.com.    704    IN    CNAME    \@.
```

...then you should _not_ get a healthy CNAME.

Fixes #60.

/cc @github/pages @antn