### PR TITLE
Request SOA instead of NS records & check name to determine if apex domain

### DIFF
--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -10,6 +10,9 @@ require "typhoeus"
 require "resolv"
 require "timeout"
 require "octokit"
+
+$LOAD_PATH.unshift File.dirname(__FILE__)
+
 require_relative "github-pages-health-check/version"
 
 if File.exist?(File.expand_path("../.env", File.dirname(__FILE__)))

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -134,7 +134,7 @@ module GitHubPages
         answers = begin
           Resolv::DNS.open do |dns|
             dns.timeouts = TIMEOUT
-            dns.getresources(absolute_domain, Resolv::DNS::Resource::IN::NS)
+            dns.getresources(absolute_domain, Resolv::DNS::Resource::IN::SOA)
           end
         rescue Timeout::Error, NoMethodError
           []

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -136,11 +136,9 @@ module GitHubPages
             dns.timeouts = TIMEOUT
             dns.getresources(absolute_domain, Resolv::DNS::Resource::IN::SOA)
           end
-        rescue Timeout::Error, NoMethodError
-          []
         end
 
-        @apex_domain = answers.any?
+        @apex_domain = answers.any? { |answer| answer.rname == absolute_domain }
       end
 
       # Should the domain be an apex record?


### PR DESCRIPTION
According to RFC 1034:

> If a CNAME RR is present at a node, no other data should be present; this ensures that the data for a canonical name and its aliases cannot be different.

If we get SOA and check that the name matches the requested domain then we should be good to call it an apex domain.