### PR TITLE
Some updates for Fastly logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+sudo: required
 language: ruby
 script: "script/cibuild"
 before_install: bundle update

--- a/lib/github-pages-health-check/cdns/fastly.rb
+++ b/lib/github-pages-health-check/cdns/fastly.rb
@@ -4,6 +4,13 @@ module GitHubPages
     # Instance of the Fastly CDN for checking IP ownership
     # Specifically not namespaced to avoid a breaking change
     class Fastly < CDN
+      # Fastly maps used by GitHub Pages.
+      HOSTNAMES = %w(
+        github.map.fastly.net
+        github.map.fastly.net.
+        sni.github.map.fastly.net
+        sni.github.map.fastly.net.
+      )
     end
   end
 end

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -393,7 +393,8 @@ module GitHubPages
       def cdn_ip?(cdn)
         return unless dns?
         dns.all? do |answer|
-          answer.class == Net::DNS::RR::A && cdn.controls_ip?(answer.address)
+          next true unless answer.class == Net::DNS::RR::A
+          cdn.controls_ip?(answer.address)
         end
       end
 

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -192,7 +192,10 @@ module GitHubPages
 
       # Is the host our Fastly CNAME?
       def fastly?
-        !!host.match(/\Agithub\.map\.fastly\.net\.?\z/i)
+        !!(
+          host.match(/\Agithub\.map\.fastly\.net\.?\z/i) ||
+          host.match(/\Asni\.github\.map\.fastly\.net\.?\z/i)
+        )
       end
 
       # Does the domain resolve to a CloudFlare-owned IP

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -192,10 +192,7 @@ module GitHubPages
 
       # Is the host our Fastly CNAME?
       def fastly?
-        !!(
-          host.match(/\Agithub\.map\.fastly\.net\.?\z/i) ||
-          host.match(/\Asni\.github\.map\.fastly\.net\.?\z/i)
-        )
+        !!host.match(/\A#{Regexp.union(Fastly::HOSTNAMES)}\z/i)
       end
 
       # Does the domain resolve to a CloudFlare-owned IP

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -263,14 +263,28 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
       end
 
       context "to fastly" do
-        let(:cname) { "github.map.fastly.net" }
+        context "github map" do
+          let(:cname) { "github.map.fastly.net" }
 
-        it "flags CNAMEs directly to fastly as invalid" do
-          expect(subject).to be_an_invalid_cname
+          it "flags CNAMEs directly to fastly as invalid" do
+            expect(subject).to be_an_invalid_cname
+          end
+
+          it "knows when the domain is CNAME'd to fastly" do
+            expect(subject).to be_a_cname_to_fastly
+          end
         end
 
-        it "knows when the domain is CNAME'd to fastly" do
-          expect(subject).to be_a_cname_to_fastly
+        context "sni.github map" do
+          let(:cname) { "sni.github.map.fastly.net" }
+
+          it "flags CNAMEs directly to fastly as invalid" do
+            expect(subject).to be_an_invalid_cname
+          end
+
+          it "knows when the domain is CNAME'd to fastly" do
+            expect(subject).to be_a_cname_to_fastly
+          end
         end
       end
 

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -211,6 +211,14 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
         it "knows it should be an a record" do
           expect(subject.should_be_a_record?).to be_truthy
         end
+
+        context "pointed to Fastly" do
+          let(:ip) { "151.101.33.147" }
+
+          it "notes it as a Fastly IP" do
+            expect(subject).to be_a_fastly_ip
+          end
+        end
       end
     end
 


### PR DESCRIPTION
- [x] Check sni.github.map as well as github.map
- [x] `Domain#cdn_ip?` should only check A records (not MX, for example)

/cc @github/pages @benbalter