### PR TITLE
Check CAA records

### DIFF
--- a/github-pages-health-check.gemspec
+++ b/github-pages-health-check.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency("gem-release", "~> 0.7")
   s.add_development_dependency("pry", "~> 0.10")
   s.add_development_dependency("rspec", "~> 3.0")
-  s.add_development_dependency("rubocop", "~> 0.52")
+  s.add_development_dependency("rubocop", "~> 0.52.0")
   s.add_development_dependency("webmock", "~> 1.21")
 end

--- a/github-pages-health-check.gemspec
+++ b/github-pages-health-check.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("addressable", "~> 2.3")
   s.add_dependency("net-dns", "~> 0.8")
+  s.add_dependency("dnsruby")
   s.add_dependency("octokit", "~> 4.0")
   s.add_dependency("public_suffix", "~> 2.0")
   s.add_dependency("typhoeus", "~> 1.3")

--- a/github-pages-health-check.gemspec
+++ b/github-pages-health-check.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.require_paths         = ["lib"]
 
   s.add_dependency("addressable", "~> 2.3")
-  s.add_dependency("net-dns", "~> 0.8")
   s.add_dependency("dnsruby")
+  s.add_dependency("net-dns", "~> 0.8")
   s.add_dependency("octokit", "~> 4.0")
   s.add_dependency("public_suffix", "~> 2.0")
   s.add_dependency("typhoeus", "~> 1.3")

--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -25,6 +25,7 @@ module GitHubPages
     autoload :Fastly,     "github-pages-health-check/cdns/fastly"
     autoload :Error,      "github-pages-health-check/error"
     autoload :Errors,     "github-pages-health-check/errors"
+    autoload :CAA,        "github-pages-health-check/caa"
     autoload :Checkable,  "github-pages-health-check/checkable"
     autoload :Domain,     "github-pages-health-check/domain"
     autoload :Repository, "github-pages-health-check/repository"

--- a/lib/github-pages-health-check/caa.rb
+++ b/lib/github-pages-health-check/caa.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "dnsruby"
 require "public_suffix"
 

--- a/lib/github-pages-health-check/caa.rb
+++ b/lib/github-pages-health-check/caa.rb
@@ -1,0 +1,48 @@
+require 'dnsruby'
+require 'public_suffix'
+
+module GitHubPages
+  module HealthCheck
+    class CAA
+      attr_reader :host
+      attr_reader :error
+
+      def initialize(host)
+        @host = host
+      end
+
+      def errored?
+        records # load the records first
+        !error.nil?
+      end
+
+      def lets_encrypt_allowed?
+        return false if errored?
+        return true unless records_present?
+        records.any? { |r| r.property_value == 'letsencrypt.org' }
+      end
+
+      def records_present?
+        return false if errored?
+        records && !records.empty?
+      end
+
+      def records
+        @records ||= (get_caa_records(host) | get_caa_records(PublicSuffix.domain(host)))
+      end
+
+      def get_caa_records(domain)
+        resolver = Dnsruby::Resolver.new
+        resolver.retry_times = 2
+        resolver.query_timeout = 2
+        nspack = begin
+          resolver.query(domain, 'CAA', 'IN')
+        rescue Exception => e
+          @error = e
+          return []
+        end
+        nspack.answer.select {|r| r.type == 'CAA' && r.property_tag == 'issue' }
+      end
+    end
+  end
+end

--- a/lib/github-pages-health-check/caa.rb
+++ b/lib/github-pages-health-check/caa.rb
@@ -1,5 +1,5 @@
-require 'dnsruby'
-require 'public_suffix'
+require "dnsruby"
+require "public_suffix"
 
 module GitHubPages
   module HealthCheck
@@ -19,7 +19,7 @@ module GitHubPages
       def lets_encrypt_allowed?
         return false if errored?
         return true unless records_present?
-        records.any? { |r| r.property_value == 'letsencrypt.org' }
+        records.any? { |r| r.property_value == "letsencrypt.org" }
       end
 
       def records_present?
@@ -36,12 +36,12 @@ module GitHubPages
         resolver.retry_times = 2
         resolver.query_timeout = 2
         nspack = begin
-          resolver.query(domain, 'CAA', 'IN')
-        rescue Exception => e
+          resolver.query(domain, "CAA", "IN")
+        rescue StandardError => e
           @error = e
           return []
         end
-        nspack.answer.select {|r| r.type == 'CAA' && r.property_tag == 'issue' }
+        nspack.answer.select { |r| r.type == "CAA" && r.property_tag == "issue" }
       end
     end
   end

--- a/spec/github_pages_health_check/caa_spec.rb
+++ b/spec/github_pages_health_check/caa_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe(GitHubPages::HealthCheck::CAA) do
+  let(:domain) { "foo.githubtest.com" }
+  subject { described_class.new(domain) }
+  let(:caa_packet_le) do
+    Dnsruby::RR.create("githubtest.com. IN CAA 0 issue \"letsencrypt.org\"")
+  end
+  let(:caa_packet_other) do
+    Dnsruby::RR.create("#{domain}. IN CAA 0 issue \"digicert.com\"")
+  end
+
+  context "a domain without CAA records" do
+    before(:each) do
+      expect(subject).to receive(:get_caa_records).with(domain).and_return([])
+      expect(subject).to receive(:get_caa_records).with("githubtest.com").and_return([])
+    end
+
+    it "knows no records exist" do
+      expect(subject).not_to be_records_present
+    end
+
+    it "allows let's encrypt" do
+      expect(subject).to be_lets_encrypt_allowed
+    end
+
+    it "does not encounter an error" do
+      expect(subject).not_to be_errored
+    end
+  end
+
+  context "a domain with LE CAA record" do
+    before(:each) do
+      expect(subject).to receive(:get_caa_records).with(domain).and_return([])
+      expect(subject).to receive(:get_caa_records)
+        .with("githubtest.com").and_return([caa_packet_le])
+    end
+
+    it "knows records exist" do
+      expect(subject).to be_records_present
+    end
+
+    it "allows let's encrypt" do
+      expect(subject).to be_lets_encrypt_allowed
+    end
+
+    it "does not encounter an error" do
+      expect(subject).not_to be_errored
+    end
+  end
+
+  context "a domain without LE CAA record" do
+    before(:each) do
+      expect(subject).to receive(:get_caa_records)
+        .with(domain).and_return([caa_packet_other])
+      expect(subject).to receive(:get_caa_records).with("githubtest.com").and_return([])
+    end
+
+    it "knows records exist" do
+      expect(subject).to be_records_present
+    end
+
+    it "doesn't let's encrypt" do
+      expect(subject).not_to be_lets_encrypt_allowed
+    end
+
+    it "does not encounter an error" do
+      expect(subject).not_to be_errored
+    end
+  end
+
+  context "a domain which errors" do
+    before(:each) do
+      expect(subject).to receive(:get_caa_records).with(domain).and_return([])
+      expect(subject).to receive(:get_caa_records).with("githubtest.com").and_return([])
+      subject.instance_variable_set(:@error, Dnsruby::ServFail.new)
+    end
+
+    it "knows no records exist" do
+      expect(subject).not_to be_records_present
+    end
+
+    it "doesn't allows let's encrypt" do
+      expect(subject).not_to be_lets_encrypt_allowed
+    end
+
+    it "surfaces the error" do
+      expect(subject).to be_errored
+      expect(subject.error.class.name).to eql("Dnsruby::ServFail")
+    end
+  end
+end


### PR DESCRIPTION
Also adds dnsruby since net-dns doesn't support CAA records. (#79)

CAA records are a way for a domain owner to limit which Certificate Authorities are authorized to issue a certificate for the given domain. These can apply at either the subdomain or parent domain level, so we have to check both to get an accurate picture of whether a particular Certificate Authority is permitted.