### PR TITLE
Custom #to_json methods must accept the state parameter

### DIFF
--- a/lib/github-pages-health-check/checkable.rb
+++ b/lib/github-pages-health-check/checkable.rb
@@ -39,9 +39,9 @@ module GitHubPages
       alias [] to_hash
       alias to_h to_hash
 
-      def to_json
+      def to_json(state = nil)
         require "json"
-        to_hash.to_json
+        to_hash.to_json(state)
       end
 
       def to_s


### PR DESCRIPTION
This allows a `Checkable` to be a member of another item that has a `to_json` method, like `Hash`.

Example:

```ruby
require 'json'
require 'github-pages-health-check'
entry = { check: GitHubPages::HealthCheck::Domain.new("www.parkermoore.de") }
entry.to_json
```

That currently fails with an `ArgumentError`, but this PR makes it work.