### PR TITLE
Target Ruby 2.2 & fix syntax errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@
 #
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.2
   Exclude:
     - 'bin/**/*'
     - 'script/**/*'

--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -34,9 +34,9 @@ module GitHubPages
     # DNS and HTTP timeout, in seconds
     TIMEOUT = 5
 
-    HUMAN_NAME = "GitHub Pages Health Check"
-    URL = "https://github.com/github/pages-health-check"
-    USER_AGENT = "Mozilla/5.0 (compatible; #{HUMAN_NAME}/#{VERSION}; +#{URL})"
+    HUMAN_NAME = "GitHub Pages Health Check".freeze
+    URL = "https://github.com/github/pages-health-check".freeze
+    USER_AGENT = "Mozilla/5.0 (compatible; #{HUMAN_NAME}/#{VERSION}; +#{URL})".freeze
 
     TYPHOEUS_OPTIONS = {
       :followlocation => true,

--- a/lib/github-pages-health-check/error.rb
+++ b/lib/github-pages-health-check/error.rb
@@ -3,8 +3,8 @@
 module GitHubPages
   module HealthCheck
     class Error < StandardError
-      DOCUMENTATION_BASE = "https://help.github.com"
-      DOCUMENTATION_PATH = "/categories/github-pages-basics/"
+      DOCUMENTATION_BASE = "https://help.github.com".freeze
+      DOCUMENTATION_PATH = "/categories/github-pages-basics/".freeze
       LOCAL_ONLY = false # Error is only used when running locally
 
       attr_reader :repository, :domain

--- a/lib/github-pages-health-check/errors/build_error.rb
+++ b/lib/github-pages-health-check/errors/build_error.rb
@@ -4,7 +4,7 @@ module GitHubPages
   module HealthCheck
     module Errors
       class BuildError < GitHubPages::HealthCheck::Error
-        DOCUMENTATION_PATH = "/articles/troubleshooting-jekyll-builds/"
+        DOCUMENTATION_PATH = "/articles/troubleshooting-jekyll-builds/".freeze
         LOCAL_ONLY = true
       end
     end

--- a/lib/github-pages-health-check/errors/deprecated_ip_error.rb
+++ b/lib/github-pages-health-check/errors/deprecated_ip_error.rb
@@ -4,7 +4,7 @@ module GitHubPages
   module HealthCheck
     module Errors
       class DeprecatedIPError < GitHubPages::HealthCheck::Error
-        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages/"
+        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages/".freeze
 
         def message
           <<-MSG

--- a/lib/github-pages-health-check/errors/invalid_a_record_error.rb
+++ b/lib/github-pages-health-check/errors/invalid_a_record_error.rb
@@ -4,7 +4,7 @@ module GitHubPages
   module HealthCheck
     module Errors
       class InvalidARecordError < GitHubPages::HealthCheck::Error
-        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages/"
+        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages/".freeze
 
         def message
           <<-MSG

--- a/lib/github-pages-health-check/errors/invalid_cname_error.rb
+++ b/lib/github-pages-health-check/errors/invalid_cname_error.rb
@@ -4,7 +4,7 @@ module GitHubPages
   module HealthCheck
     module Errors
       class InvalidCNAMEError < GitHubPages::HealthCheck::Error
-        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages/"
+        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages/".freeze
 
         def message
           <<-MSG

--- a/lib/github-pages-health-check/errors/invalid_dns_error.rb
+++ b/lib/github-pages-health-check/errors/invalid_dns_error.rb
@@ -4,7 +4,7 @@ module GitHubPages
   module HealthCheck
     module Errors
       class InvalidDNSError < GitHubPages::HealthCheck::Error
-        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages/"
+        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages/".freeze
 
         def message
           "Domain's DNS record could not be retrieved"

--- a/lib/github-pages-health-check/errors/invalid_domain_error.rb
+++ b/lib/github-pages-health-check/errors/invalid_domain_error.rb
@@ -4,7 +4,7 @@ module GitHubPages
   module HealthCheck
     module Errors
       class InvalidDomainError < GitHubPages::HealthCheck::Error
-        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages/"
+        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages/".freeze
 
         def message
           "Domain is not a valid domain"

--- a/lib/github-pages-health-check/errors/not_served_by_pages_error.rb
+++ b/lib/github-pages-health-check/errors/not_served_by_pages_error.rb
@@ -4,7 +4,7 @@ module GitHubPages
   module HealthCheck
     module Errors
       class NotServedByPagesError < GitHubPages::HealthCheck::Error
-        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages/"
+        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages/".freeze
 
         def message
           "Domain does not resolve to the GitHub Pages server"

--- a/lib/github-pages-health-check/printer.rb
+++ b/lib/github-pages-health-check/printer.rb
@@ -4,7 +4,7 @@ module GitHubPages
   module HealthCheck
     class Printer
       PRETTY_LEFT_WIDTH = 11
-      PRETTY_JOINER = " | "
+      PRETTY_JOINER = " | ".freeze
 
       attr_reader :health_check
 

--- a/lib/github-pages-health-check/repository.rb
+++ b/lib/github-pages-health-check/repository.rb
@@ -45,11 +45,11 @@ module GitHubPages
       alias reason build_error
 
       def build_duration
-        last_build&.duration
+        last_build && last_build.duration
       end
 
       def last_built
-        last_build&.updated_at
+        last_build && last_build.updated_at
       end
 
       def domain

--- a/lib/github-pages-health-check/site.rb
+++ b/lib/github-pages-health-check/site.rb
@@ -14,7 +14,7 @@ module GitHubPages
       end
 
       def check!
-        [domain, repository].each { |check| check&.check! }
+        [domain, repository].compact.each(&:check!)
         true
       end
 

--- a/lib/github-pages-health-check/version.rb
+++ b/lib/github-pages-health-check/version.rb
@@ -2,6 +2,6 @@
 
 module GitHubPages
   module HealthCheck
-    VERSION = "1.7.1"
+    VERSION = "1.7.1".freeze
   end
 end


### PR DESCRIPTION
Targeting Ruby 2.4 meant rubocop insisted on using the `&.` operator which is a no-go in Ruby 2.2

Ruby 2.2 is still supported by github-pages: https://github.com/github/pages-gem/pull/554