### PR TITLE
Fix should_be_a_record? to response *.github.com domains

### DIFF
--- a/lib/github-pages-health-check/caa.rb
+++ b/lib/github-pages-health-check/caa.rb
@@ -39,7 +39,11 @@ module GitHubPages
 
       def get_caa_records(domain)
         return [] if domain.nil?
-        query(domain).select { |r| r.type == Dnsruby::Types::CAA && r.property_tag == "issue" }
+        query(domain).select { |r| issue_caa_record?(r) }
+      end
+
+      def issue_caa_record?(record)
+        record.type == Dnsruby::Types::CAA && record.property_tag == "issue"
       end
 
       def query(domain)

--- a/lib/github-pages-health-check/caa.rb
+++ b/lib/github-pages-health-check/caa.rb
@@ -10,6 +10,8 @@ module GitHubPages
       attr_reader :error
 
       def initialize(host)
+        raise ArgumentError, "host cannot be nil" if host.nil?
+
         @host = host
       end
 
@@ -36,7 +38,8 @@ module GitHubPages
       private
 
       def get_caa_records(domain)
-        query(domain).select { |r| r.type == "CAA" && r.property_tag == "issue" }
+        return [] if domain.nil?
+        query(domain).select { |r| r.type == Dnsruby::Types::CAA && r.property_tag == "issue" }
       end
 
       def query(domain)
@@ -44,8 +47,8 @@ module GitHubPages
         resolver.retry_times = 2
         resolver.query_timeout = 2
         begin
-          resolver.query(domain, "CAA", "IN").answer
-        rescue StandardError => e
+          resolver.query(domain, Dnsruby::Types::CAA).answer
+        rescue Dnsruby::ResolvError => e
           @error = e
           []
         end

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -356,7 +356,7 @@ module GitHubPages
       private
 
       def caa
-        @caa ||= GitHubPages::HealthCheck::CAA.new(absolute_domain)
+        @caa ||= GitHubPages::HealthCheck::CAA.new(host)
       end
 
       # The domain's response to HTTP(S) requests, following redirects

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -151,7 +151,7 @@ module GitHubPages
 
       # Should the domain use an A record?
       def should_be_a_record?
-        apex_domain? || mx_records_present?
+        !pages_io_domain? && (apex_domain? || mx_records_present?)
       end
 
       def should_be_cname_record?
@@ -187,6 +187,11 @@ module GitHubPages
       end
 
       # Is the host a *.github.io domain?
+      def pages_io_domain?
+        !!host.match(/\A[\w-]+\.github\.(io)\.?\z/i)
+      end
+
+      # Is the host a *.github.(io|com) domain?
       def pages_domain?
         !!host.match(/\A[\w-]+\.github\.(io|com)\.?\z/i)
       end

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -149,9 +149,9 @@ module GitHubPages
         PublicSuffix.domain(host) == host
       end
 
-      # Should the domain be an apex record?
+      # Should the domain use an A record?
       def should_be_a_record?
-        !pages_domain? && (apex_domain? || mx_records_present?)
+        apex_domain? || mx_records_present?
       end
 
       def should_be_cname_record?

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -217,19 +217,20 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
       end
 
       context "a domain with an MX record" do
-        before(:each) { allow(subject).to receive(:dns) { [a_packet, mx_packet] } }
         let(:domain) { "blog.parkermoore.de" }
-
-        it "knows it should be an a record" do
-          expect(subject.should_be_a_record?).to be_truthy
+        before(:each) do
+          allow(subject).to receive(:dns) { [a_packet, mx_packet] }
+          stub_request(:head, "http://#{domain}")
+            .to_return(:status => 200, :headers => { "Server" => "GitHub.com" })
         end
+
+        it { is_expected.to be_should_be_a_record }
+        it { is_expected.to be_valid }
 
         context "pointed to Fastly" do
           let(:ip) { "151.101.33.147" }
 
-          it "notes it as a Fastly IP" do
-            expect(subject).to be_a_fastly_ip
-          end
+          it { is_expected.to be_a_fastly_ip }
         end
       end
     end


### PR DESCRIPTION
We have resources.github.com which has MX records. According to the DNS spec, it then *cannot* have a CNAME record, as we would normally recommend. This PR allows A records for *.github.com, while still disallowing it for *.github.io (not sure why we checked that in the first place?).

It also fixes a problem where we were requesting CAA records with a `nil` domain, so I fixed it to catch nils better. The nil was from `PublicSuffix.domain(host)`.

Fixes https://github.com/github/resources/issues/200