### PR TITLE
Check authoritative nameservers for a domain

### DIFF
--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -48,6 +48,31 @@ module GitHubPages
       }
     }.freeze
 
+    class << self
+      def default_resolver
+        Dnsruby::Resolver.new(
+          retry_times: 2,
+          query_timeout: 2,
+          dnssec: true,
+        )
+      end
+
+      def nameservers_for_domain(domain)
+        default_resolver.query(domain, Dnsruby::Types::NS).answer.map do |answer|
+          next answer.nsdname if answer.type == Dnsruby::Types::NS
+        end.compact
+      end
+
+      def build_resolver(domain)
+        Dnsruby::Resolver.new(
+          nameservers: nameservers_for_domain(domain),
+          retry_times: 2,
+          query_timeout: 2,
+          dnssec: true,
+        )
+      end
+    end
+
     # surpress warn-level feedback due to unsupported record types
     def self.without_warnings(&block)
       warn_level = $VERBOSE

--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -28,11 +28,12 @@ module GitHubPages
     autoload :Checkable,  "github-pages-health-check/checkable"
     autoload :Domain,     "github-pages-health-check/domain"
     autoload :Repository, "github-pages-health-check/repository"
+    autoload :Resolver,   "github-pages-health-check/resolver"
     autoload :Site,       "github-pages-health-check/site"
     autoload :Printer,    "github-pages-health-check/printer"
 
     # DNS and HTTP timeout, in seconds
-    TIMEOUT = 5
+    TIMEOUT = 7
 
     HUMAN_NAME = "GitHub Pages Health Check".freeze
     URL = "https://github.com/github/pages-health-check".freeze
@@ -47,31 +48,6 @@ module GitHubPages
         "User-Agent" => USER_AGENT
       }
     }.freeze
-
-    class << self
-      def default_resolver
-        Dnsruby::Resolver.new(
-          retry_times: 2,
-          query_timeout: 2,
-          dnssec: true,
-        )
-      end
-
-      def nameservers_for_domain(domain)
-        default_resolver.query(domain, Dnsruby::Types::NS).answer.map do |answer|
-          next answer.nsdname if answer.type == Dnsruby::Types::NS
-        end.compact
-      end
-
-      def build_resolver(domain)
-        Dnsruby::Resolver.new(
-          nameservers: nameservers_for_domain(domain),
-          retry_times: 2,
-          query_timeout: 2,
-          dnssec: true,
-        )
-      end
-    end
 
     # surpress warn-level feedback due to unsupported record types
     def self.without_warnings(&block)

--- a/lib/github-pages-health-check/caa.rb
+++ b/lib/github-pages-health-check/caa.rb
@@ -47,11 +47,8 @@ module GitHubPages
       end
 
       def query(domain)
-        resolver = Dnsruby::Resolver.new
-        resolver.retry_times = 2
-        resolver.query_timeout = 2
         begin
-          resolver.query(domain, Dnsruby::Types::CAA).answer
+          GitHubPages::HealthCheck.build_resolver(domain).query(domain, Dnsruby::Types::CAA).answer
         rescue Dnsruby::ResolvError => e
           @error = e
           []

--- a/lib/github-pages-health-check/caa.rb
+++ b/lib/github-pages-health-check/caa.rb
@@ -47,12 +47,10 @@ module GitHubPages
       end
 
       def query(domain)
-        begin
-          GitHubPages::HealthCheck.build_resolver(domain).query(domain, Dnsruby::Types::CAA).answer
-        rescue Dnsruby::ResolvError => e
-          @error = e
-          []
-        end
+        GitHubPages::HealthCheck::Resolver.new(domain).query(Dnsruby::Types::CAA)
+      rescue Dnsruby::ResolvError, Dnsruby::ResolvTimeout => e
+        @error = e
+        []
       end
     end
   end

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -262,10 +262,7 @@ module GitHubPages
       end
 
       def resolver
-        @resolver ||= Dnsruby::Resolver.new
-        @resolver.retry_times = 2
-        @resolver.query_timeout = 2
-        @resolver
+        @resolver ||= GitHubPages::HealthCheck.build_resolver(host)
       end
 
       # Are we even able to get the DNS record?

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -253,7 +253,7 @@ module GitHubPages
           GitHubPages::HealthCheck.without_warnings do
             next if host.nil?
             REQUESTED_RECORD_TYPES
-              .map { |type| resolver.query(absolute_domain, type).answer }
+              .map { |type| resolver.query(type) }
               .flatten.uniq
           end
         end
@@ -262,7 +262,7 @@ module GitHubPages
       end
 
       def resolver
-        @resolver ||= GitHubPages::HealthCheck.build_resolver(host)
+        @resolver ||= GitHubPages::HealthCheck::Resolver.new(absolute_domain)
       end
 
       # Are we even able to get the DNS record?

--- a/lib/github-pages-health-check/resolver.rb
+++ b/lib/github-pages-health-check/resolver.rb
@@ -9,7 +9,7 @@ module GitHubPages
         :dnssec => true
       }.freeze
 
-      REQUIRES_AUTHORITATIVE_ANSWER = [
+      PREFERS_AUTHORITATIVE_ANSWER = [
         Dnsruby::Types::A,
         Dnsruby::Types::CAA,
         Dnsruby::Types::MX
@@ -29,7 +29,7 @@ module GitHubPages
 
       # rubocop:disable Metrics/AbcSize
       def query(type)
-        if REQUIRES_AUTHORITATIVE_ANSWER.include?(type)
+        if PREFERS_AUTHORITATIVE_ANSWER.include?(type)
           answer = authoritative_resolver.query(domain, type).answer
           return answer unless answer.empty?
         end

--- a/lib/github-pages-health-check/resolver.rb
+++ b/lib/github-pages-health-check/resolver.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module GitHubPages
+  module HealthCheck
+    class Resolver
+      DEFAULT_RESOLVER_OPTIONS = {
+        :retry_times => 2,
+        :query_timeout => 5,
+        :dnssec => true
+      }.freeze
+
+      REQUIRES_AUTHORITATIVE_ANSWER = [
+        Dnsruby::Types::A,
+        Dnsruby::Types::CAA,
+        Dnsruby::Types::MX
+      ].freeze
+
+      class << self
+        def default_resolver
+          @default_resolver ||= Dnsruby::Resolver.new(DEFAULT_RESOLVER_OPTIONS)
+        end
+      end
+
+      attr_reader :domain
+
+      def initialize(domain)
+        @domain = domain
+      end
+
+      # rubocop:disable Metrics/AbcSize
+      def query(type)
+        if REQUIRES_AUTHORITATIVE_ANSWER.include?(type)
+          answer = authoritative_resolver.query(domain, type).answer
+          return answer unless answer.empty?
+        end
+
+        self.class.default_resolver.query(domain, type).answer
+      rescue Dnsruby::ResolvTimeout, Dnsruby::ResolvError
+        self.class.default_resolver.query(domain, type).answer
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      private
+
+      def authoritative_resolver
+        return self.class.default_resolver if nameservers.nil? || nameservers.empty?
+
+        Dnsruby::Resolver.new(DEFAULT_RESOLVER_OPTIONS.merge(:nameservers => nameservers))
+      end
+
+      def nameservers
+        @nameservers ||= begin
+          self.class.default_resolver.query(domain, Dnsruby::Types::NS).answer.map do |rr|
+            next rr.nsdname.to_s if rr.type == Dnsruby::Types::NS
+          end.compact
+        end
+      end
+    end
+  end
+end

--- a/spec/github_pages_health_check/resolver_spec.rb
+++ b/spec/github_pages_health_check/resolver_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe(GitHubPages::HealthCheck::Resolver) do
+  let(:domain) { "www.example.com" }
+  subject { described_class.new(domain) }
+
+  it "uses authoritative NS servers to query A records" do
+    expect(described_class.default_resolver).to \
+      receive(:query).with(domain, Dnsruby::Types::NS).and_call_original
+    expect(subject.send(:authoritative_resolver)).to \
+      receive(:query).with(domain, Dnsruby::Types::A).and_call_original
+    subject.query(Dnsruby::Types::A)
+  end
+
+  it "uses authoritative NS servers to query CAA records, but falls back" do
+    expect(described_class.default_resolver).to \
+      receive(:query).with(domain, Dnsruby::Types::NS).and_call_original
+    expect(subject.send(:authoritative_resolver)).to \
+      receive(:query).with(domain, Dnsruby::Types::CAA).and_call_original
+    expect(described_class.default_resolver).to \
+      receive(:query).with(domain, Dnsruby::Types::CAA).and_call_original
+    subject.query(Dnsruby::Types::CAA)
+  end
+
+  it "uses authoritative NS servers to query MX records, but falls back" do
+    expect(described_class.default_resolver).to \
+      receive(:query).with(domain, Dnsruby::Types::NS).and_call_original
+    expect(subject.send(:authoritative_resolver)).to \
+      receive(:query).with(domain, Dnsruby::Types::MX).and_call_original
+    expect(described_class.default_resolver).to \
+      receive(:query).with(domain, Dnsruby::Types::MX).and_call_original
+    subject.query(Dnsruby::Types::MX)
+  end
+
+  it "uses the default resolver for CNAME records" do
+    expect(described_class.default_resolver).to \
+      receive(:query).with(domain, Dnsruby::Types::NS).and_call_original
+    expect(described_class.default_resolver).to \
+      receive(:query).with(domain, Dnsruby::Types::CNAME).and_call_original
+    expect(subject.send(:authoritative_resolver)).not_to receive(:query)
+    subject.query(Dnsruby::Types::CNAME)
+  end
+end


### PR DESCRIPTION
DNS caching causes all sorts of issues, because checking the domain once caches the record
on many layers between the querying host and the authoritative nameservers.

To get around caching, simply ask the authoritative nameservers for the domain, bypassing
the DNS in the local network and all networks in between.