### PR TITLE
Add a check for AAAA records

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -128,16 +128,17 @@ Metrics/ClassLength:
     - lib/github-pages-health-check/domain.rb
 
 Metrics/CyclomaticComplexity:
-  Max: 8
+  Max: 9
   Exclude:
     - lib/github-pages-health-check/printer.rb
 
 Metrics/PerceivedComplexity:
-  Max: 8
+  Max: 9
   Exclude:
     - lib/github-pages-health-check/printer.rb
 
 Metrics/AbcSize:
+  Max: 17
   Exclude:
     - lib/github-pages-health-check/printer.rb
 

--- a/lib/github-pages-health-check/errors/invalid_aaaa_record_error.rb
+++ b/lib/github-pages-health-check/errors/invalid_aaaa_record_error.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module GitHubPages
+  module HealthCheck
+    module Errors
+      class InvalidAAAARecordError < GitHubPages::HealthCheck::Error
+        DOCUMENTATION_PATH = "/articles/setting-up-a-custom-domain-with-github-pages/".freeze
+
+        def message
+          <<-MSG
+             Your site's DNS settings are using a custom subdomain, #{domain.host},
+             that's set up with an AAAA record. GitHub Pages currently does not support
+             IPv6.
+           MSG
+        end
+      end
+    end
+  end
+end

--- a/lib/github-pages-health-check/resolver.rb
+++ b/lib/github-pages-health-check/resolver.rb
@@ -27,7 +27,6 @@ module GitHubPages
         @domain = domain
       end
 
-      # rubocop:disable Metrics/AbcSize
       def query(type)
         if PREFERS_AUTHORITATIVE_ANSWER.include?(type)
           answer = authoritative_resolver.query(domain, type).answer
@@ -38,7 +37,6 @@ module GitHubPages
       rescue Dnsruby::ResolvTimeout, Dnsruby::ResolvError
         self.class.default_resolver.query(domain, type).answer
       end
-      # rubocop:enable Metrics/AbcSize
 
       private
 

--- a/spec/github_pages_health_check/errors_spec.rb
+++ b/spec/github_pages_health_check/errors_spec.rb
@@ -4,6 +4,6 @@ require "spec_helper"
 
 RSpec.describe(GitHubPages::HealthCheck::Errors) do
   it "returns the errors" do
-    expect(GitHubPages::HealthCheck::Errors.all.count).to eql(9)
+    expect(GitHubPages::HealthCheck::Errors.all.count).to eql(10)
   end
 end


### PR DESCRIPTION
GitHub pages only supports ipv4 at this time. Having AAAA records for a
pages domain is wrong and will lead to certificate enrollment failures,
as Let's Encrypt would connect to the wrong host.