### PR TITLE
Allow Domain to specify what kind of nameservers it wants to use

### DIFF
--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -19,18 +19,19 @@ end
 
 module GitHubPages
   module HealthCheck
-    autoload :CDN,        "github-pages-health-check/cdn"
-    autoload :CloudFlare, "github-pages-health-check/cdns/cloudflare"
-    autoload :Fastly,     "github-pages-health-check/cdns/fastly"
-    autoload :Error,      "github-pages-health-check/error"
-    autoload :Errors,     "github-pages-health-check/errors"
-    autoload :CAA,        "github-pages-health-check/caa"
-    autoload :Checkable,  "github-pages-health-check/checkable"
-    autoload :Domain,     "github-pages-health-check/domain"
-    autoload :Repository, "github-pages-health-check/repository"
-    autoload :Resolver,   "github-pages-health-check/resolver"
-    autoload :Site,       "github-pages-health-check/site"
-    autoload :Printer,    "github-pages-health-check/printer"
+    autoload :CDN,            "github-pages-health-check/cdn"
+    autoload :CloudFlare,     "github-pages-health-check/cdns/cloudflare"
+    autoload :Fastly,         "github-pages-health-check/cdns/fastly"
+    autoload :Error,          "github-pages-health-check/error"
+    autoload :Errors,         "github-pages-health-check/errors"
+    autoload :CAA,            "github-pages-health-check/caa"
+    autoload :Checkable,      "github-pages-health-check/checkable"
+    autoload :Domain,         "github-pages-health-check/domain"
+    autoload :RedundantCheck, "github-pages-health-check/redundant_check"
+    autoload :Repository,     "github-pages-health-check/repository"
+    autoload :Resolver,       "github-pages-health-check/resolver"
+    autoload :Site,           "github-pages-health-check/site"
+    autoload :Printer,        "github-pages-health-check/printer"
 
     # DNS and HTTP timeout, in seconds
     TIMEOUT = 7

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -89,6 +89,10 @@ module GitHubPages
         https_eligible? caa_error
       ].freeze
 
+      def self.redundant(host)
+        GitHubPages::HealthCheck::RedundantCheck.new(host).check
+      end
+
       def initialize(host, nameservers: :default)
         unless host.is_a? String
           raise ArgumentError, "Expected string, got #{host.class}"

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -3,7 +3,7 @@
 module GitHubPages
   module HealthCheck
     class Domain < Checkable
-      attr_reader :host
+      attr_reader :host, :resolver, :nameservers
 
       LEGACY_IP_ADDRESSES = [
         # Legacy GitHub Datacenter
@@ -89,12 +89,15 @@ module GitHubPages
         https_eligible? caa_error
       ].freeze
 
-      def initialize(host)
+      def initialize(host, nameservers: :default)
         unless host.is_a? String
           raise ArgumentError, "Expected string, got #{host.class}"
         end
 
         @host = normalize_host(host)
+        @nameservers = nameservers
+        @resolver = GitHubPages::HealthCheck::Resolver.new(host,
+          :nameservers => nameservers)
       end
 
       # Runs all checks, raises an error if invalid
@@ -269,10 +272,6 @@ module GitHubPages
         @dns = nil
       end
 
-      def resolver
-        @resolver ||= GitHubPages::HealthCheck::Resolver.new(absolute_domain)
-      end
-
       # Are we even able to get the DNS record?
       def dns?
         !(dns.nil? || dns.empty?)
@@ -371,7 +370,7 @@ module GitHubPages
       private
 
       def caa
-        @caa ||= GitHubPages::HealthCheck::CAA.new(host)
+        @caa ||= GitHubPages::HealthCheck::CAA.new(host, :nameservers => nameservers)
       end
 
       # The domain's response to HTTP(S) requests, following redirects

--- a/lib/github-pages-health-check/redundant_check.rb
+++ b/lib/github-pages-health-check/redundant_check.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module GitHubPages
+  module HealthCheck
+    class RedundantCheck
+      extend Forwardable
+
+      TIMEOUT = 5 # seconds
+
+      attr_reader :domain
+
+      def initialize(domain)
+        @domain = domain
+      end
+
+      def check
+        @check ||= (checks.find(&:valid?) || check_with_default_nameservers)
+      end
+
+      def_delegator :check, :reason, :reason
+      def_delegator :check, :valid?, :valid?
+
+      def https_eligible?
+        checks.any?(&:https_eligible?)
+      end
+
+      private
+
+      def checks
+        @checks ||= %i[default authoritative].map do |ns|
+          GitHubPages::HealthCheck::Domain.new(domain, :nameservers => ns)
+        end
+      end
+
+      def check_with_default_nameservers
+        @check_with_default_nameservers ||= checks.find { |c| c.nameservers == :default }
+      end
+    end
+  end
+end

--- a/lib/github-pages-health-check/repository.rb
+++ b/lib/github-pages-health-check/repository.rb
@@ -54,7 +54,7 @@ module GitHubPages
 
       def domain
         return if cname.nil?
-        @domain ||= GitHubPages::HealthCheck::Domain.new(cname)
+        @domain ||= GitHubPages::HealthCheck::Domain.redundant(cname)
       end
 
       private

--- a/lib/github-pages-health-check/site.rb
+++ b/lib/github-pages-health-check/site.rb
@@ -10,7 +10,7 @@ module GitHubPages
         @domain = @repository.domain
       rescue GitHubPages::HealthCheck::Errors::InvalidRepositoryError
         @repository = nil
-        @domain = Domain.new(repository_or_domain)
+        @domain = Domain.redundant(repository_or_domain)
       end
 
       def check!

--- a/script/cibuild
+++ b/script/cibuild
@@ -6,4 +6,6 @@ script/bootstrap
 
 script/test
 script/check-cdn-ips
+bundle exec script/check www.parkermoore.de | grep 'valid?: true'
+bundle exec script/check ben.balter.com | grep 'valid?: true'
 bundle exec gem build github-pages-health-check.gemspec

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -462,6 +462,7 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
     let(:headers) { {} }
 
     before do
+      allow(subject).to receive(:dns) { [a_packet] }
       stub_request(:head, domain)
         .to_return(:status => status, :headers => headers)
     end

--- a/spec/github_pages_health_check/redundant_check_spec.rb
+++ b/spec/github_pages_health_check/redundant_check_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+RSpec.describe(GitHubPages::HealthCheck::RedundantCheck) do
+  let(:domain) { "www.parkermoore.de" }
+  subject { described_class.new(domain) }
+  before(:each) do
+    stub_request(:head, "http://#{domain}/")
+      .to_return(:status => 200, :body => "", :headers => { "Server" => "GitHub.com" })
+  end
+
+  it { is_expected.to be_valid }
+  it { is_expected.to be_https_eligible }
+
+  it "has a link to the check which was most valid" do
+    expect(subject.check).not_to be_nil
+    expect(subject.check).to be_valid
+  end
+end

--- a/spec/github_pages_health_check/repository_spec.rb
+++ b/spec/github_pages_health_check/repository_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe(GitHubPages::HealthCheck::Repository) do
   let(:repo) { "#{owner}/#{repo_name}" }
   let(:access_token) { nil }
   subject { described_class.new(repo, :access_token => access_token) }
+  before(:each) do
+    stub_request(:head, "https://#{repo_name}/")
+      .to_return(:status => 200, :body => "", :headers => { "Server" => "GitHub.com" })
+  end
 
   context "constructor" do
     context "an invalid repository" do

--- a/spec/github_pages_health_check_spec.rb
+++ b/spec/github_pages_health_check_spec.rb
@@ -3,9 +3,15 @@
 require "spec_helper"
 
 RSpec.describe(GitHubPages::HealthCheck) do
+  let(:domain) { "pages.github.com" }
+  before(:each) do
+    stub_request(:head, "https://#{domain}/")
+      .to_return(:status => 200, :body => "", :headers => { "Server" => "GitHub.com" })
+  end
+
   it "checks" do
-    check = GitHubPages::HealthCheck.check("pages.github.com")
+    check = GitHubPages::HealthCheck.check(domain)
     expect(check.class).to eql(GitHubPages::HealthCheck::Site)
-    expect(check.domain.host).to eql("pages.github.com")
+    expect(check.domain.host).to eql(domain)
   end
 end


### PR DESCRIPTION
Options include 'default', 'authoritative', or an array of nameserver IP's.

Added `GitHubPages::HealthCheck::RedundantCheck.new(domain)` which provides `#valid?`, `#https_eligible?` and `#check`. The last method, `#check`, returns the `Domain` instance which was "most valid".