### PR TITLE
https_eligible?: do not allow AAAA records

### DIFF
--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -362,7 +362,7 @@ module GitHubPages
       # Can an HTTPS certificate be issued for this domain?
       def https_eligible?
         (cname_to_github_user_domain? || pointed_to_new_primary_ips?) &&
-          caa.lets_encrypt_allowed?
+          !aaaa_record_present? && caa.lets_encrypt_allowed?
       end
 
       # Any errors querying CAA records


### PR DESCRIPTION
Let's Encrypt prefers IPv6 records when issuing a certificate for a domain. We should filter any domains which have AAAA records, since that is not compatible with HTTPS eligibility.