### PR TITLE
Add support for querying public resolvers

### DIFF
--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -80,13 +80,13 @@ module GitHubPages
       ].freeze
 
       HASH_METHODS = %i[
-        host uri dns_resolves? proxied? cloudflare_ip? fastly_ip?
-        old_ip_address? a_record? cname_record? mx_records_present?
-        valid_domain? apex_domain? should_be_a_record?
+        host uri nameservers dns_resolves? proxied? cloudflare_ip?
+        fastly_ip? old_ip_address? a_record? cname_record?
+        mx_records_present? valid_domain? apex_domain? should_be_a_record?
         cname_to_github_user_domain? cname_to_pages_dot_github_dot_com?
         cname_to_fastly? pointed_to_github_pages_ip? pages_domain?
-        served_by_pages? valid? reason valid_domain?
-        https? enforces_https? https_error https_eligible? caa_error
+        served_by_pages? valid? reason valid_domain? https?
+        enforces_https? https_error https_eligible? caa_error
       ].freeze
 
       def self.redundant(host)

--- a/lib/github-pages-health-check/redundant_check.rb
+++ b/lib/github-pages-health-check/redundant_check.rb
@@ -27,13 +27,17 @@ module GitHubPages
       private
 
       def checks
-        @checks ||= %i[default authoritative].map do |ns|
+        @checks ||= %i[default authoritative public].map do |ns|
           GitHubPages::HealthCheck::Domain.new(domain, :nameservers => ns)
         end
       end
 
       def check_with_default_nameservers
         @check_with_default_nameservers ||= checks.find { |c| c.nameservers == :default }
+      end
+
+      def check_with_public_nameservers
+        @check_with_public_nameservers ||= checks.find { |c| c.nameservers == :public }
       end
     end
   end

--- a/lib/github-pages-health-check/resolver.rb
+++ b/lib/github-pages-health-check/resolver.rb
@@ -8,6 +8,10 @@ module GitHubPages
         :query_timeout => 5,
         :dnssec        => false
       }.freeze
+      PUBLIC_NAMESERVERS = %w(
+        8.8.8.8
+        1.1.1.1
+      ).freeze
 
       class << self
         def default_resolver
@@ -39,6 +43,10 @@ module GitHubPages
                       when :authoritative
                         Dnsruby::Resolver.new(DEFAULT_RESOLVER_OPTIONS.merge(
                           :nameservers => authoritative_nameservers
+                        ))
+                      when :public
+                        Dnsruby::Resolver.new(DEFAULT_RESOLVER_OPTIONS.merge(
+                          :nameservers => PUBLIC_NAMESERVERS
                         ))
                       when Array
                         Dnsruby::Resolver.new(DEFAULT_RESOLVER_OPTIONS.merge(

--- a/spec/github_pages_health_check/site_spec.rb
+++ b/spec/github_pages_health_check/site_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe(GitHubPages::HealthCheck::Site) do
         end
 
         context "hash" do
-          let(:valid_values) { [true, false, nil] }
+          let(:valid_values) { [true, false, nil, :default] }
 
           it "returns a valid values" do
             hash = subject.to_hash


### PR DESCRIPTION
Querying a resolver like 8.8.8.8 and 1.1.1.1 enforce DNSSEC internally and provide another possibility for valid answers in the redundant check.