### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ruby:2.5.1-alpine3.7
+RUN apk add --update --no-cache build-base libcurl \
+ && gem install github-pages-health-check \
+ && apk del build-base \
+ && echo "require 'github-pages-health-check'; puts GitHubPages::HealthCheck::Site.new(ARGV[0]).to_json" > to_json.rb
+ENTRYPOINT [ "ruby", "to_json.rb" ]


### PR DESCRIPTION
Had to diagnose an issue with my GithubPages site, but didn't have `ruby` installed (and it seemed kinda annoying to install `ruby` on Windows), so I created this `Dockerfile`.

If you build the image (`docker build .`), you can run a check for any site with a single command (`docker run <imageId> <siteUrl>`) and get the results back as JSON.

Ideally, however, you wouldn't have to build this yourself, but could run it directly from DockerHub, for example: `docker run github/pages-health-check <siteUrl>`

Are you guys interested in adding this? 🙂 