### PR TITLE
Disable DNS Result Caching

### DIFF
--- a/lib/github-pages-health-check/resolver.rb
+++ b/lib/github-pages-health-check/resolver.rb
@@ -6,7 +6,8 @@ module GitHubPages
       DEFAULT_RESOLVER_OPTIONS = {
         :retry_times   => 2,
         :query_timeout => 5,
-        :dnssec        => false
+        :dnssec        => false,
+        :do_caching    => false
       }.freeze
       PUBLIC_NAMESERVERS = %w(
         8.8.8.8


### PR DESCRIPTION
[Dnsruby](https://github.com/alexdalitz/dnsruby) by default appears to cache results internally, which prevents the redundant checking functionality as implemented in https://github.com/github/pages-health-check/pull/90 and https://github.com/github/pages-health-check/pull/98 from performing as expected.

In particular, the earlier cached entries from the default nameservers are returned when later trying the authoritative and public nameservers.

This PR disables this caching in Dnsruby.

While rudimentary, I was able to test this was effective by performing the following two queries in `script/console`, spaced sufficiently apart to be able to determine by the returned TTLs that they were not sharing a local cached entry:

```
GitHubPages::HealthCheck::Domain.new("pages.github.com", :nameservers => :default).dns
GitHubPages::HealthCheck::Domain.new("pages.github.com", :nameservers => :public).dns
```

Without this fix, it is obvious that they are sharing the same cache entry, as the results from these two queries return TTLs that align perfectly.