### PR TITLE
Improved support for internationalised domains

### DIFF
--- a/lib/github-pages-health-check.rb
+++ b/lib/github-pages-health-check.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "dnsruby"
+require "addressable/idna"
 require "addressable/uri"
 require "ipaddr"
 require "public_suffix"

--- a/lib/github-pages-health-check/caa.rb
+++ b/lib/github-pages-health-check/caa.rb
@@ -33,7 +33,10 @@ module GitHubPages
       end
 
       def records
-        @records ||= (get_caa_records(host) | get_caa_records(PublicSuffix.domain(host)))
+        unicode_host = Addressable::IDNA.to_unicode(host)
+        @records ||= begin
+          get_caa_records(host) | get_caa_records(PublicSuffix.domain(unicode_host))
+        end
       end
 
       private

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -100,7 +100,7 @@ module GitHubPages
 
         @host = normalize_host(host)
         @nameservers = nameservers
-        @resolver = GitHubPages::HealthCheck::Resolver.new(host,
+        @resolver = GitHubPages::HealthCheck::Resolver.new(@host,
           :nameservers => nameservers)
       end
 

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -147,7 +147,8 @@ module GitHubPages
       # Used as an escape hatch to prevent false positives on DNS checkes
       def valid_domain?
         return @valid if defined? @valid
-        @valid = PublicSuffix.valid?(host, :default_rule => nil)
+        unicode_host = Addressable::IDNA.to_unicode(host)
+        @valid = PublicSuffix.valid?(unicode_host, :default_rule => nil)
       end
 
       # Is this domain an apex domain, meaning a CNAME would be innapropriate
@@ -160,7 +161,8 @@ module GitHubPages
         # It's aware of multi-step top-level domain names:
         # E.g. PublicSuffix.domain("blog.digital.gov.uk") # => "digital.gov.uk"
         # For apex-level domain names, DNS providers do not support CNAME records.
-        PublicSuffix.domain(host) == host
+        unicode_host = Addressable::IDNA.to_unicode(host)
+        PublicSuffix.domain(unicode_host) == unicode_host
       end
 
       # Should the domain use an A record?

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -100,7 +100,7 @@ module GitHubPages
 
         @host = normalize_host(host)
         @nameservers = nameservers
-        @resolver = GitHubPages::HealthCheck::Resolver.new(@host,
+        @resolver = GitHubPages::HealthCheck::Resolver.new(self.host,
           :nameservers => nameservers)
       end
 

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -423,8 +423,8 @@ module GitHubPages
       # Return the hostname.
       def normalize_host(domain)
         domain = domain.strip.chomp(".")
-        host = Addressable::URI.parse(domain).host
-        host ||= Addressable::URI.parse("http://#{domain}").host
+        host = Addressable::URI.parse(domain).normalized_host
+        host ||= Addressable::URI.parse("http://#{domain}").normalized_host
         host unless host.to_s.empty?
       rescue Addressable::URI::InvalidURIError
         nil

--- a/lib/github-pages-health-check/resolver.rb
+++ b/lib/github-pages-health-check/resolver.rb
@@ -32,7 +32,7 @@ module GitHubPages
       end
 
       def query(type)
-        resolver.query(domain, type).answer
+        resolver.query(Addressable::IDNA.to_ascii(domain), type).answer
       end
 
       private


### PR DESCRIPTION
I came across a couple of issues with [internationalised domain names](https://en.wikipedia.org/wiki/Internationalized_domain_name) today that I hope to solve in this PR.

---

PublicSuffix doesn't support Punycode encoded internationalised public suffixes, and instead expects them to be Unicode encoded (weppos/publicsuffix-ruby#46). If you feed in a Punycode encoded   public suffix, then no result, or a more broader result, may be returned.

Impacts:

- `Domain.valid_domain?` can return `false`, leading to almost everything in `Domain` failing, including `Domain.https_eligible?` always returning `false`.
- `CAA.records` isn't able to retrieve the CAA records for the apex domain.

---

Unfortunately Dnsruby is the reverse way around, and expects the internationalised domain to be Punycode encoded, and exceptions if fed a Unicode encoded internationalised domain (alexdalitz/dnsruby#94).

Impacts:

- Feeding a Unicode encoded internationalised domain in to most of the `GitHubPages::HealthCheck::Domain` or `GitHubPages::HealthCheck::CAA` methods will lead to a Dnsruby exception.

--- 

To work around these issues, I am feeding the domain in to Addressable's `normalized_host` method, which converts the internationalised domain to Punycode encoding, which appears to be the generally more accepted way to work with domains in code. I am then re-encoding in Unicode where required (which is just when using PublicSufix for now).

Addressable's `normalized_host` method will also take care of removing a trailing dot, making our existing way to doing this redundant.

These encoding transformations cope fine with a non-internationalised domain.

I have added tests, though these actually pass even without these fixes, as to surface this bug you need to use a domain with internationalised characters in the public suffix. I didn't want to pick a random name, since it may be in use, or registered in the future. It might be worth us registering a domain in one of the [internationalised country code top-level domain's](https://en.wikipedia.org/wiki/Internationalized_country_code_top-level_domain) which appears in the public suffix list.

__Glossary__:

__Public Suffix__: As defined at https://publicsuffix.org/, an example is the `com` portion of `pages.github.com`.
__Apex Domain__: As defined at https://help.github.com/articles/about-supported-custom-domains/#apex-domains, an example is the `github.com portion of `pages.github.com`.