### PR TITLE
Update CAA verification to check immediate parent rather than public suffix domain

### DIFF
--- a/lib/github-pages-health-check/caa.rb
+++ b/lib/github-pages-health-check/caa.rb
@@ -33,9 +33,8 @@ module GitHubPages
       end
 
       def records
-        unicode_host = Addressable::IDNA.to_unicode(host)
         @records ||= begin
-          get_caa_records(host) | get_caa_records(PublicSuffix.domain(unicode_host))
+          get_caa_records(host) | get_caa_records(host.split(".").drop(1).join("."))
         end
       end
 

--- a/spec/github_pages_health_check/caa_spec.rb
+++ b/spec/github_pages_health_check/caa_spec.rb
@@ -3,10 +3,13 @@
 require "spec_helper"
 
 RSpec.describe(GitHubPages::HealthCheck::CAA) do
-  let(:domain) { "foo.githubtest.com" }
+  let(:domain) { "foo.sub.githubtest.com" }
   subject { described_class.new(domain) }
   let(:caa_packet_le) do
-    Dnsruby::RR.create("githubtest.com. IN CAA 0 issue \"letsencrypt.org\"")
+    Dnsruby::RR.create("sub.githubtest.com. IN CAA 0 issue \"letsencrypt.org\"")
+  end
+  let(:caa_packet_le_apex) do
+    Dnsruby::RR.create("githubtest.com. IN CAA 0 issue \"digicert.com\"")
   end
   let(:caa_packet_other) do
     Dnsruby::RR.create("#{domain}. IN CAA 0 issue \"digicert.com\"")
@@ -15,7 +18,7 @@ RSpec.describe(GitHubPages::HealthCheck::CAA) do
   context "a domain without CAA records" do
     before(:each) do
       expect(subject).to receive(:query).with(domain).and_return([])
-      expect(subject).to receive(:query).with("githubtest.com").and_return([])
+      expect(subject).to receive(:query).with("sub.githubtest.com").and_return([])
     end
 
     it "knows no records exist" do
@@ -35,7 +38,7 @@ RSpec.describe(GitHubPages::HealthCheck::CAA) do
     before(:each) do
       expect(subject).to receive(:query).with(domain).and_return([])
       expect(subject).to receive(:query)
-        .with("githubtest.com").and_return([caa_packet_le])
+        .with("sub.githubtest.com").and_return([caa_packet_le])
     end
 
     it "knows records exist" do
@@ -54,7 +57,7 @@ RSpec.describe(GitHubPages::HealthCheck::CAA) do
   context "a domain without LE CAA record" do
     before(:each) do
       expect(subject).to receive(:query).with(domain).and_return([caa_packet_other])
-      expect(subject).to receive(:query).with("githubtest.com").and_return([])
+      expect(subject).to receive(:query).with("sub.githubtest.com").and_return([])
     end
 
     it "knows records exist" do
@@ -70,10 +73,30 @@ RSpec.describe(GitHubPages::HealthCheck::CAA) do
     end
   end
 
+  context "a sub-subdomain with an apex CAA record" do
+    before(:each) do
+      expect(subject).to receive(:query).with(domain).and_return([])
+      expect(subject).to receive(:query).with("sub.githubtest.com").and_return([])
+      expect(subject).to_not receive(:query).with("githubtest.com")
+    end
+
+    it "knows no records exist" do
+      expect(subject).not_to be_records_present
+    end
+
+    it "allows let's encrypt" do
+      expect(subject).to be_lets_encrypt_allowed
+    end
+
+    it "does not encounter an error" do
+      expect(subject).not_to be_errored
+    end
+  end
+
   context "a domain which errors" do
     before(:each) do
       expect(subject).to receive(:query).with(domain).and_return([])
-      expect(subject).to receive(:query).with("githubtest.com").and_return([])
+      expect(subject).to receive(:query).with("sub.githubtest.com").and_return([])
       subject.instance_variable_set(:@error, Dnsruby::ServFail.new)
     end
 


### PR DESCRIPTION
Fixes #103 by passing `host.split(".").drop(1).join(".")` through to `get_caa_records` as the fallback instead of `PublicSuffix.domain(unicode_host)`.

This is in line with [RFC 6844](https://tools.ietf.org/html/rfc6844) errata [eid5065](https://www.rfc-editor.org/errata/eid5065), as implemented by Let's Encrypt.

`host.split(".").drop(1).join(".")` will return the parent FQDN immediately above `host`. For example `sub.example.com` for `www.sub.example.com`.

#### `www.sub.example.com` Example

##### Before

```ruby
get_caa_records("www.sub.example.com") | get_caa_records("example.com")
```

##### After

```ruby
get_caa_records("www.sub.example.com") | get_caa_records("sub.example.com")
```