### PR TITLE
Improve CAA checking to follow the CNAME per the CAA spec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,7 +61,7 @@ Style/PercentLiteralDelimiters:
     '%r': '{}'
 
 Metrics/LineLength:
-  Max: 90
+  Max: 95
   Severity: warning
   Exclude:
     - github-pages-health-check.gemspec

--- a/lib/github-pages-health-check/caa.rb
+++ b/lib/github-pages-health-check/caa.rb
@@ -14,6 +14,9 @@ module GitHubPages
 
         @host = host
         @nameservers = nameservers
+
+        raise "Host cannot be blank" if host.nil? || host.empty?
+        raise "Nameservers cannot be nil" if nameservers.nil?
       end
 
       def errored?

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -381,7 +381,11 @@ module GitHubPages
       private
 
       def caa
-        @caa ||= GitHubPages::HealthCheck::CAA.new(host, :nameservers => nameservers)
+        @caa ||= if cname?
+                   GitHubPages::HealthCheck::CAA.new(cname.host, :nameservers => :default)
+                 else
+                   GitHubPages::HealthCheck::CAA.new(host, :nameservers => nameservers)
+                 end
       end
 
       # The domain's response to HTTP(S) requests, following redirects

--- a/spec/github_pages_health_check/caa_spec.rb
+++ b/spec/github_pages_health_check/caa_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 RSpec.describe(GitHubPages::HealthCheck::CAA) do
   let(:domain) { "foo.sub.githubtest.com" }
-  subject { described_class.new(domain) }
+  subject { described_class.new(domain, :nameservers => :default) }
   let(:caa_packet_le) do
     Dnsruby::RR.create("sub.githubtest.com. IN CAA 0 issue \"letsencrypt.org\"")
   end

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -953,22 +953,30 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
     end
 
     context "CNAME record pointed to username" do
+      let(:domain) { "example.dc.gov" }
       let(:cname) { "foobar.github.io" }
-      before(:each) { allow(subject).to receive(:dns) { [cname_packet] } }
-      before(:each) { allow(subject.send(:caa)).to receive(:query) { [cname_packet] } }
+      before(:each) do
+        allow(subject).to receive(:dns) { [cname_packet] }
+        allow(subject.send(:caa)).to receive(:query).with(cname).and_return([])
+        allow(subject.send(:caa)).to receive(:query).with("github.io").and_return([])
+      end
 
       it { is_expected.to be_https_eligible }
 
       context "with bad CAA records" do
         let(:caa_domain) { "digicert.com" }
-        before(:each) { allow(subject.send(:caa)).to receive(:query) { [caa_packet] } }
+        before(:each) do
+          allow(subject.send(:caa)).to receive(:query).with(cname).and_return([caa_packet])
+        end
 
         it { is_expected.not_to be_https_eligible }
       end
 
       context "with good CAA records" do
         let(:caa_domain) { "letsencrypt.org" }
-        before(:each) { allow(subject.send(:caa)).to receive(:query) { [caa_packet] } }
+        before(:each) do
+          allow(subject.send(:caa)).to receive(:query).with(cname).and_return([caa_packet])
+        end
 
         it { is_expected.to be_https_eligible }
       end
@@ -980,14 +988,18 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
 
         context "with bad CAA records" do
           let(:caa_domain) { "digicert.com" }
-          before(:each) { allow(subject.send(:caa)).to receive(:query) { [caa_packet] } }
+          before(:each) do
+            allow(subject.send(:caa)).to receive(:query).with(cname).and_return([caa_packet])
+          end
 
           it { is_expected.not_to be_https_eligible }
         end
 
         context "with good CAA records" do
           let(:caa_domain) { "letsencrypt.org" }
-          before(:each) { allow(subject.send(:caa)).to receive(:query) { [caa_packet] } }
+          before(:each) do
+            allow(subject.send(:caa)).to receive(:query).with(cname).and_return([caa_packet])
+          end
 
           it { is_expected.to be_https_eligible }
         end
@@ -1000,14 +1012,18 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
 
         context "with bad CAA records" do
           let(:caa_domain) { "digicert.com" }
-          before(:each) { allow(subject.send(:caa)).to receive(:query) { [caa_packet] } }
+          before(:each) do
+            allow(subject.send(:caa)).to receive(:query).with(cname).and_return([caa_packet])
+          end
 
           it { is_expected.not_to be_https_eligible }
         end
 
         context "with good CAA records" do
           let(:caa_domain) { "letsencrypt.org" }
-          before(:each) { allow(subject.send(:caa)).to receive(:query) { [caa_packet] } }
+          before(:each) do
+            allow(subject.send(:caa)).to receive(:query).with(cname).and_return([caa_packet])
+          end
 
           it { is_expected.to be_https_eligible }
         end
@@ -1016,21 +1032,27 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
 
     context "CNAME record pointed elsewhere" do
       let(:cname) { "jinglebells.com" }
-      before(:each) { allow(subject).to receive(:dns) { [cname_packet] } }
-      before(:each) { allow(subject.send(:caa)).to receive(:query) { [cname_packet] } }
+      before(:each) do
+        allow(subject).to receive(:dns) { [cname_packet] }
+        allow(subject.send(:caa)).to receive(:query).with(cname).and_return([])
+      end
 
       it { is_expected.not_to be_https_eligible }
 
       context "with bad CAA records" do
         let(:caa_domain) { "digicert.com" }
-        before(:each) { allow(subject.send(:caa)).to receive(:query) { [caa_packet] } }
+        before(:each) do
+          allow(subject.send(:caa)).to receive(:query).with(cname).and_return([caa_packet])
+        end
 
         it { is_expected.not_to be_https_eligible }
       end
 
       context "with good CAA records" do
         let(:caa_domain) { "letsencrypt.org" }
-        before(:each) { allow(subject.send(:caa)).to receive(:query) { [caa_packet] } }
+        before(:each) do
+          allow(subject.send(:caa)).to receive(:query).with(cname).and_return([caa_packet])
+        end
 
         it { is_expected.not_to be_https_eligible }
       end


### PR DESCRIPTION
The CAA spec says for CNAMEs that if no CAA records exist for the current domain,
then the CAA records for the CNAME should be used.

https://tools.ietf.org/html/rfc6844#section-4

Am I reading that right? I'm not sure how best to restructure this code to check for this.

/cc @github/pages