### PR TITLE
Bump public_suffix requirement up to 3.0

### DIFF
--- a/github-pages-health-check.gemspec
+++ b/github-pages-health-check.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency("addressable", "~> 2.3")
   s.add_dependency("dnsruby", "~> 1.60")
   s.add_dependency("octokit", "~> 4.0")
-  s.add_dependency("public_suffix", "~> 2.0")
+  s.add_dependency("public_suffix", "~> 3.0")
   s.add_dependency("typhoeus", "~> 1.3")
 
   s.add_development_dependency("dotenv", "~> 1.0")


### PR DESCRIPTION
Bumps the Public Suffix gem, which is now in the 3.x release series as of early last year. This bump will allow GitHub Pages HTTPS support for a number of newer Public Suffixes.

/cc @github/pages 