### PR TITLE
Support Private Public Suffix TLDs when verifying that a domain is valid

### DIFF
--- a/lib/github-pages-health-check/caa.rb
+++ b/lib/github-pages-health-check/caa.rb
@@ -24,11 +24,13 @@ module GitHubPages
       def lets_encrypt_allowed?
         return false if errored?
         return true unless records_present?
+
         records.any? { |r| r.property_value == "letsencrypt.org" }
       end
 
       def records_present?
         return false if errored?
+
         records && !records.empty?
       end
 
@@ -42,6 +44,7 @@ module GitHubPages
 
       def get_caa_records(domain)
         return [] if domain.nil?
+
         query(domain).select { |r| issue_caa_record?(r) }
       end
 

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -147,7 +147,9 @@ module GitHubPages
       def valid_domain?
         return @valid if defined? @valid
         unicode_host = Addressable::IDNA.to_unicode(host)
-        @valid = PublicSuffix.valid?(unicode_host, :default_rule => nil)
+        @valid = PublicSuffix.valid?(unicode_host,
+                                     :default_rule => nil,
+                                     :ignore_private => true)
       end
 
       # Is this domain an apex domain, meaning a CNAME would be innapropriate
@@ -161,7 +163,9 @@ module GitHubPages
         # E.g. PublicSuffix.domain("blog.digital.gov.uk") # => "digital.gov.uk"
         # For apex-level domain names, DNS providers do not support CNAME records.
         unicode_host = Addressable::IDNA.to_unicode(host)
-        PublicSuffix.domain(unicode_host) == unicode_host
+        PublicSuffix.domain(unicode_host,
+                            :default_rule => nil,
+                            :ignore_private => true) == unicode_host
       end
 
       # Should the domain use an A record?

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -113,31 +113,37 @@ module GitHubPages
         raise Errors::InvalidCNAMEError, :domain => self      if invalid_cname?
         raise Errors::InvalidAAAARecordError, :domain => self if invalid_aaaa_record?
         raise Errors::NotServedByPagesError, :domain => self  unless served_by_pages?
+
         true
       end
 
       def deprecated_ip?
         return @deprecated_ip if defined? @deprecated_ip
+
         @deprecated_ip = (valid_domain? && a_record? && old_ip_address?)
       end
 
       def invalid_aaaa_record?
         return @invalid_aaaa_record if defined? @invalid_aaaa_record
+
         @invalid_aaaa_record = (valid_domain? && should_be_a_record? &&
                                 aaaa_record_present?)
       end
 
       def invalid_a_record?
         return @invalid_a_record if defined? @invalid_a_record
+
         @invalid_a_record = (valid_domain? && a_record? && !should_be_a_record?)
       end
 
       def invalid_cname?
         return @invalid_cname if defined? @invalid_cname
+
         @invalid_cname = begin
           return false unless valid_domain?
           return false if github_domain? || apex_domain?
           return true  if cname_to_pages_dot_github_dot_com? || cname_to_fastly?
+
           !cname_to_github_user_domain? && should_be_cname_record?
         end
       end
@@ -146,6 +152,7 @@ module GitHubPages
       # Used as an escape hatch to prevent false positives on DNS checkes
       def valid_domain?
         return @valid if defined? @valid
+
         unicode_host = Addressable::IDNA.to_unicode(host)
         @valid = PublicSuffix.valid?(unicode_host,
                                      :default_rule => nil,
@@ -185,6 +192,7 @@ module GitHubPages
       # Are any of the domain's A records pointing elsewhere?
       def non_github_pages_ip_present?
         return unless dns?
+
         a_records = dns.select { |answer| answer.type == Dnsruby::Types::A }
 
         a_records.any? { |answer| !github_pages_ip?(answer.address.to_s) }
@@ -260,6 +268,7 @@ module GitHubPages
         return false if cname_to_github_user_domain?
         return false if cname_to_pages_dot_github_dot_com?
         return false if cname_to_fastly? || fastly_ip?
+
         served_by_pages?
       end
 
@@ -274,9 +283,11 @@ module GitHubPages
       def dns
         return @dns if defined? @dns
         return unless valid_domain?
+
         @dns = Timeout.timeout(TIMEOUT) do
           GitHubPages::HealthCheck.without_warnings do
             next if host.nil?
+
             REQUESTED_RECORD_TYPES
               .map { |type| resolver.query(type) }
               .flatten.uniq
@@ -304,11 +315,13 @@ module GitHubPages
       # Is this domain's first response an A record?
       def a_record?
         return unless dns?
+
         dns.first.type == Dnsruby::Types::A
       end
 
       def aaaa_record_present?
         return unless dns?
+
         dns.any? { |answer| answer.type == Dnsruby::Types::AAAA }
       end
 
@@ -316,6 +329,7 @@ module GitHubPages
       def cname_record?
         return unless dns?
         return false unless cname
+
         cname.valid_domain?
       end
       alias cname? cname_record?
@@ -324,11 +338,13 @@ module GitHubPages
       # Returns nil if the domain is not a CNAME
       def cname
         return unless dns.first.type == Dnsruby::Types::CNAME
+
         @cname ||= Domain.new(dns.first.cname.to_s)
       end
 
       def mx_records_present?
         return unless dns?
+
         dns.any? { |answer| answer.type == Dnsruby::Types::MX }
       end
 
@@ -365,6 +381,7 @@ module GitHubPages
       # Does this domain redirect HTTP requests to HTTPS?
       def enforces_https?
         return false unless https? && http_response.headers["Location"]
+
         redirect = Addressable::URI.parse(http_response.headers["Location"])
         redirect.scheme == "https" && redirect.host == host
       end
@@ -379,6 +396,7 @@ module GitHubPages
       # Any errors querying CAA records
       def caa_error
         return nil unless caa.errored?
+
         caa.error.class.name
       end
 

--- a/lib/github-pages-health-check/repository.rb
+++ b/lib/github-pages-health-check/repository.rb
@@ -15,6 +15,7 @@ module GitHubPages
         unless name_with_owner.match(REPO_REGEX)
           raise Errors::InvalidRepositoryError
         end
+
         parts = name_with_owner.split("/")
         @owner = parts.first
         @name  = parts.last
@@ -28,6 +29,7 @@ module GitHubPages
 
       def check!
         raise Errors::BuildError.new(:repository => self), build_error unless built?
+
         true
       end
 
@@ -54,6 +56,7 @@ module GitHubPages
 
       def domain
         return if cname.nil?
+
         @domain ||= GitHubPages::HealthCheck::Domain.redundant(cname)
       end
 
@@ -61,6 +64,7 @@ module GitHubPages
 
       def client
         raise Errors::MissingAccessTokenError if @access_token.nil?
+
         @client ||= Octokit::Client.new(:access_token => @access_token)
       end
 

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -545,6 +545,18 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
       end
     end
 
+    context "private tlds in the public suffix list" do
+      let(:domain) { "githubusercontent.com" }
+      let(:cname)  { "something.example.com" }
+      let(:headers) { { :server => "GitHub.com" } }
+      before(:each) { allow(subject).to receive(:dns) { [cname_packet] } }
+
+      it "doesn't error out on private tlds in the public suffix list" do
+        expect(subject).to be_served_by_pages
+        expect(subject).to be_valid
+      end
+    end
+
     context "domains with unicode encoding" do
       let(:domain) { "dómain.example.com" }
       let(:cname)  { "sómething.example.com" }


### PR DESCRIPTION
The existing logic considers a custom domain that itself is directly considered a Private TLD in the Public Suffix List as not valid, preventing the issuance of a certificate.

Private TLDs in this context are legitimate Internet resolvable domains that have been added to the Public Suffix List by their owners. An example of a Private TLD is `githubusercontent.com`.

The existing logic would deem `subdomain.githubusercontent.com` as valid, but `githubusercontent.com` as not valid.

It is acceptable for Private TLD's to host content directly. Additionally, Let's Encrypt will issue a certificate for a Private TLD. Therefore it is possible for a Private TLD in this context, such as `githubusercontent.com`, to be used as a custom domain with GitHub Pages.

As our Public Suffix usage here is intended to check that a domain is a legitimate ICANN domain, we don't need to pay any attention to the private TLDs in the Public Suffix List. These will already be covered off by the ICANN TLDs in the Public Suffix List. 

/cc @github/pages