### PR TITLE
For CNAME records, only check CAA records for the domain, not its parent

### DIFF
--- a/lib/github-pages-health-check/caa.rb
+++ b/lib/github-pages-health-check/caa.rb
@@ -35,14 +35,12 @@ module GitHubPages
       end
 
       def records
-        @records ||= get_caa_records(host)
-      end
+        return @records if defined?(@records)
 
-      def parent_domain_allows_lets_encrypt?
-        @parent_domain_allows_lets_encrypt ||= begin
-          self.class.new(host.split(".").drop(1).join("."), :nameservers => nameservers)
-            .lets_encrypt_allowed?
-        end
+        @records = get_caa_records(host)
+        @records = get_caa_records(parent_host) if @records.nil? || @records.empty?
+
+        @records
       end
 
       private
@@ -66,6 +64,10 @@ module GitHubPages
 
       def resolver(domain)
         GitHubPages::HealthCheck::Resolver.new(domain, :nameservers => nameservers)
+      end
+
+      def parent_host
+        host.split(".").drop(1).join(".")
       end
     end
   end

--- a/lib/github-pages-health-check/caa.rb
+++ b/lib/github-pages-health-check/caa.rb
@@ -35,9 +35,11 @@ module GitHubPages
       end
 
       def records
-        @records ||= begin
-          get_caa_records(host) | get_caa_records(host.split(".").drop(1).join("."))
-        end
+        @records ||= get_caa_records(host)
+      end
+
+      def parent_domain_allows_lets_encrypt?
+        self.class.new(host.split(".").drop(1).join("."), nameservers: nameservers).lets_encrypt_allowed?
       end
 
       private

--- a/lib/github-pages-health-check/caa.rb
+++ b/lib/github-pages-health-check/caa.rb
@@ -9,7 +9,7 @@ module GitHubPages
     class CAA
       attr_reader :host, :error, :nameservers
 
-      def initialize(host, nameservers: nil)
+      def initialize(host, nameservers: :default)
         raise ArgumentError, "host cannot be nil" if host.nil?
 
         @host = host
@@ -39,7 +39,10 @@ module GitHubPages
       end
 
       def parent_domain_allows_lets_encrypt?
-        self.class.new(host.split(".").drop(1).join("."), nameservers: nameservers).lets_encrypt_allowed?
+        @parent_domain_allows_lets_encrypt ||= begin
+          self.class.new(host.split(".").drop(1).join("."), :nameservers => nameservers)
+            .lets_encrypt_allowed?
+        end
       end
 
       private

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -395,7 +395,7 @@ module GitHubPages
         # Must be a CNAME or point to our IPs.
 
         # Only check the one domain if a CNAME. Don't check the parent domain.
-        return caa.lets_encrypt_allowed? if cname_to_github_user_domain?
+        return true if cname_to_github_user_domain?
 
         # Check CAA records for the full domain and its parent domain.
         pointed_to_github_pages_ip? &&

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -388,9 +388,19 @@ module GitHubPages
 
       # Can an HTTPS certificate be issued for this domain?
       def https_eligible?
-        (cname_to_github_user_domain? || pointed_to_github_pages_ip?) &&
-          !aaaa_record_present? && !non_github_pages_ip_present? &&
-          caa.lets_encrypt_allowed?
+        # Can't have any IP's which aren't GitHub's present.
+        return false if non_github_pages_ip_present?
+        # Can't have any AAAA records present
+        return false if aaaa_record_present?
+        # Must be a CNAME or point to our IPs.
+
+        # Only check the one domain if a CNAME. Don't check the parent domain.
+        return caa.lets_encrypt_allowed? if cname_to_github_user_domain?
+
+        # Check CAA records for the full domain and its parent domain.
+        pointed_to_github_pages_ip? &&
+          caa.lets_encrypt_allowed? &&
+          caa.parent_domain_allows_lets_encrypt?
       end
 
       # Any errors querying CAA records

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -398,9 +398,7 @@ module GitHubPages
         return true if cname_to_github_user_domain?
 
         # Check CAA records for the full domain and its parent domain.
-        pointed_to_github_pages_ip? &&
-          caa.lets_encrypt_allowed? &&
-          caa.parent_domain_allows_lets_encrypt?
+        pointed_to_github_pages_ip? && caa.lets_encrypt_allowed?
       end
 
       # Any errors querying CAA records

--- a/spec/github_pages_health_check/caa_spec.rb
+++ b/spec/github_pages_health_check/caa_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe(GitHubPages::HealthCheck::CAA) do
   context "a domain without CAA records" do
     before(:each) do
       expect(subject).to receive(:query).with(domain).and_return([])
+      expect(subject).to receive(:query).with(parent_domain).and_return([])
     end
 
     it "knows no records exist" do
@@ -73,6 +74,7 @@ RSpec.describe(GitHubPages::HealthCheck::CAA) do
   context "a domain which errors" do
     before(:each) do
       expect(subject).to receive(:query).with(domain).and_return([])
+      expect(subject).to receive(:query).with(parent_domain).and_return([])
       subject.instance_variable_set(:@error, Dnsruby::ServFail.new)
     end
 
@@ -87,32 +89,6 @@ RSpec.describe(GitHubPages::HealthCheck::CAA) do
     it "surfaces the error" do
       expect(subject).to be_errored
       expect(subject.error.class.name).to eql("Dnsruby::ServFail")
-    end
-  end
-
-  context "a domain with a parent domain" do
-    it "truthy when no CAA records for parent domain" do
-      expect(GitHubPages::HealthCheck::Resolver.default_resolver).to \
-        receive(:query)
-        .with(parent_domain, Dnsruby::Types::CAA)
-        .and_return(Struct.new(:answer).new([]))
-      expect(subject.parent_domain_allows_lets_encrypt?).to be_truthy
-    end
-
-    it "truthy when LE CAA record for parent domain" do
-      expect(GitHubPages::HealthCheck::Resolver.default_resolver).to \
-        receive(:query)
-        .with(parent_domain, Dnsruby::Types::CAA)
-        .and_return(Struct.new(:answer).new([caa_packet_other, caa_packet_le]))
-      expect(subject.parent_domain_allows_lets_encrypt?).to be_truthy
-    end
-
-    it "falsey when only non-LE CAA records for parent domain" do
-      expect(GitHubPages::HealthCheck::Resolver.default_resolver).to \
-        receive(:query)
-        .with(parent_domain, Dnsruby::Types::CAA)
-        .and_return(Struct.new(:answer).new([caa_packet_other]))
-      expect(subject.parent_domain_allows_lets_encrypt?).to be_falsey
     end
   end
 end

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -975,7 +975,7 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
         let(:caa_domain) { "digicert.com" }
         before(:each) { allow(subject.send(:caa)).to receive(:query) { [caa_packet] } }
 
-        it { is_expected.not_to be_https_eligible }
+        it { is_expected.to be_https_eligible }
       end
 
       context "with good CAA records" do
@@ -994,7 +994,7 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
           let(:caa_domain) { "digicert.com" }
           before(:each) { allow(subject.send(:caa)).to receive(:query) { [caa_packet] } }
 
-          it { is_expected.not_to be_https_eligible }
+          it { is_expected.to be_https_eligible }
         end
 
         context "with good CAA records" do
@@ -1014,7 +1014,7 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
           let(:caa_domain) { "digicert.com" }
           before(:each) { allow(subject.send(:caa)).to receive(:query) { [caa_packet] } }
 
-          it { is_expected.not_to be_https_eligible }
+          it { is_expected.to be_https_eligible }
         end
 
         context "with good CAA records" do


### PR DESCRIPTION
This PR attempts to fix a bug in our CAA checking.

1. Where the domain in question is a CNAME to username.github.io, then only check the CAA records for that one domain. Its parent SHOULD NOT be checked.
2. Where the domain in question uses A records to point to GitHub Pages IPs, then check the CAA records for both it and its parent domain.

Example:

1. `www.example.com` is a CNAME to `example.github.io`. Check only CAA on `www.example.com`.
2. `foobar.example.com` uses A records to point to GitHub Pages IPs. Check CAA for `foobar.example.com` AND `example.com`.

/cc @github/pages
