### PR TITLE
Silence warnings triggered by Ruby 2.7

### DIFF
--- a/github-pages-health-check.gemspec
+++ b/github-pages-health-check.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency("addressable", "~> 2.3")
   s.add_dependency("dnsruby", "~> 1.60")
   s.add_dependency("octokit", "~> 4.0")
-  s.add_dependency("public_suffix", "~> 3.0")
+  s.add_dependency("public_suffix", ">= 3.0")
   s.add_dependency("typhoeus", "~> 1.3")
 
   s.add_development_dependency("dotenv", "~> 1.0")

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -104,18 +104,20 @@ module GitHubPages
       end
 
       # Runs all checks, raises an error if invalid
+      # rubocop:disable Metrics/AbcSize
       def check!
-        raise Errors::InvalidDomainError, :domain => self unless valid_domain?
-        raise Errors::InvalidDNSError, :domain => self    unless dns_resolves?
-        raise Errors::DeprecatedIPError, :domain => self if deprecated_ip?
+        raise Errors::InvalidDomainError.new :domain => self unless valid_domain?
+        raise Errors::InvalidDNSError.new :domain => self    unless dns_resolves?
+        raise Errors::DeprecatedIPError.new :domain => self if deprecated_ip?
         return true if proxied?
-        raise Errors::InvalidARecordError, :domain => self    if invalid_a_record?
-        raise Errors::InvalidCNAMEError, :domain => self      if invalid_cname?
-        raise Errors::InvalidAAAARecordError, :domain => self if invalid_aaaa_record?
-        raise Errors::NotServedByPagesError, :domain => self  unless served_by_pages?
+        raise Errors::InvalidARecordError.new :domain => self    if invalid_a_record?
+        raise Errors::InvalidCNAMEError.new :domain => self      if invalid_cname?
+        raise Errors::InvalidAAAARecordError.new :domain => self if invalid_aaaa_record?
+        raise Errors::NotServedByPagesError.new :domain => self  unless served_by_pages?
 
         true
       end
+      # rubocop:enable Metrics/AbcSize
 
       def deprecated_ip?
         return @deprecated_ip if defined? @deprecated_ip


### PR DESCRIPTION
Ruby 2.7 adds some new warnings. In particular, previously if a method was
defined with keyword arguments, you could create a hash and pass it to the
method, and Ruby wouldn't complain.

Now, however, Ruby wants you to explicitly pass **the_hash instead of just
the_hash where keyword arguments are expected.

The version of public_suffix that this codebase was relying on emitted the
following warnings:


    lib/ruby/gems/2.7.0/gems/public_suffix-3.1.1/lib/public_suffix/list.rb:51:
       warning: Using the last argument as keyword parameters is
    deprecated;
       maybe ** should be added to the call
    lib/public_suffix/list.rb:69:
       warning: The called method `parse' is defined here

v4.0.3 fixes these warnings.

I had to set the version specifier in the gemspec to >= 3.0 in order to manage
to upgrade github/github, otherwise bundler gets its dependencies in a tizzy.

Once github/github is updated, we could update this to be ~> 4.0