### PR TITLE
Guard on cname method having valid dns

### DIFF
--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -339,6 +339,7 @@ module GitHubPages
       # The domain to which this domain's CNAME resolves
       # Returns nil if the domain is not a CNAME
       def cname
+        return unless dns?
         cnames = dns.take_while { |answer| answer.type == Dnsruby::Types::CNAME }
         return if cnames.empty?
 
@@ -405,7 +406,7 @@ module GitHubPages
 
       # Any errors querying CAA records
       def caa_error
-        return nil unless caa.errored?
+        return nil unless caa&.errored?
 
         caa.error.class.name
       end

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -340,6 +340,7 @@ module GitHubPages
       # Returns nil if the domain is not a CNAME
       def cname
         return unless dns?
+
         cnames = dns.take_while { |answer| answer.type == Dnsruby::Types::CNAME }
         return if cnames.empty?
 

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -836,6 +836,10 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
       it "knows when the DNS doesn't resolve" do
         expect(subject.dns?).to be_falsy
       end
+
+      it "treats cname as nil if DNS doesn't resolve" do
+        expect(subject.cname).to be_nil
+      end
     end
 
     context "an invalid domain" do


### PR DESCRIPTION
With the changes in #125, if a domain name is not setup we can hit a scenario where DNS is not responding when we go to check `cname`. This throws an exception instead of returning nil, so it prevents the hash from being created.