### PR TITLE
feat(domain): report if an SOA record exists for a domain

### DIFF
--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -85,7 +85,7 @@ module GitHubPages
         cname_to_fastly? pointed_to_github_pages_ip?
         non_github_pages_ip_present? pages_domain?
         served_by_pages? valid? reason valid_domain? https?
-        enforces_https? https_error https_eligible? caa_error
+        enforces_https? https_error https_eligible? caa_error dns_zone_soa?
       ].freeze
 
       def self.redundant(host)
@@ -161,17 +161,11 @@ module GitHubPages
                                      :ignore_private => true)
       end
 
-      # Is this domain an apex domain? Or is it a subdomain that behaves like
-      # an apex (i.e. SOA record present)?
-      #
-      # Callers should be aware that this can return truthy for domains that
-      # are not apex-level (i.e. subdomain.apex.com).
+      # Is this domain an apex domain, meaning a CNAME would be innapropriate
       def apex_domain?
         return @apex_domain if defined?(@apex_domain)
 
         return unless valid_domain?
-
-        return true if dns_zone_soa?
 
         # PublicSuffix.domain pulls out the apex-level domain name.
         # E.g. PublicSuffix.domain("techblog.netflix.com") # => "netflix.com"
@@ -185,6 +179,9 @@ module GitHubPages
       end
 
       # Does the domain have an SOA record published?
+      #
+      # Callers should be aware that this can return truthy for domains that
+      # are not apex-level (i.e. subdomain.apex.com).
       def dns_zone_soa?
         return @soa_records if defined?(@soa_records)
         return false unless dns?

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -265,8 +265,12 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
           before(:each) { allow(subject).to receive(:dns) { [soa_packet] } }
           let(:domain) { soa_domain }
 
-          it "allows child zones with an SOA to be an Apex" do
-            expect(subject.should_be_a_record?).to be_truthy
+          it "disallows child zones with an SOA to be an Apex" do
+            expect(subject.should_be_a_record?).to be_falsy
+          end
+
+          it "reports whether child zones publish an SOA record" do
+            expect(subject.dns_zone_soa?).to be_truthy
           end
         end
       end


### PR DESCRIPTION
In https://github.com/github/pages-health-check/pull/127 we take the approach to abstract SOA record checking from callers to `apex_domain?`.  Existing callers make assumptions around this value not being a subdomain so we may introduce bugs by adding additional logic to the function.

This PR instead exposes the new `dns_zone_soa?` method so that callers can take both pieces of information into account when deciding how to handle cases where subdomains behave like apex domains by having SOA records published.