### PR TITLE
feat(domain): report if an SOA record exists for a domain

### DIFF
--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -85,7 +85,7 @@ module GitHubPages
         cname_to_fastly? pointed_to_github_pages_ip?
         non_github_pages_ip_present? pages_domain?
         served_by_pages? valid? reason valid_domain? https?
-        enforces_https? https_error https_eligible? caa_error
+        enforces_https? https_error https_eligible? caa_error dns_zone_soa?
       ].freeze
 
       def self.redundant(host)
@@ -175,6 +175,18 @@ module GitHubPages
         PublicSuffix.domain(unicode_host,
                             :default_rule => nil,
                             :ignore_private => true) == unicode_host
+      end
+
+      # Does the domain have an SOA record published?
+      #
+      # Callers should be aware that this can return truthy for domains that
+      # are not apex-level (i.e. subdomain.apex.com).
+      def dns_zone_soa?
+        return @soa_records if defined?(@soa_records)
+        return false unless dns?
+
+        soa_records = dns.select { |answer| answer.type == Dnsruby::Types::SOA }
+        soa_records.any?
       end
 
       # Should the domain use an A record?

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -257,6 +257,21 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
         end
       end
 
+      ["private.dns.zone"].each do |soa_domain|
+        context "given #{soa_domain}" do
+          before(:each) { allow(subject).to receive(:dns) { [soa_packet] } }
+          let(:domain) { soa_domain }
+
+          it "disallows child zones with an SOA to be an Apex" do
+            expect(subject.should_be_a_record?).to be_falsy
+          end
+
+          it "reports whether child zones publish an SOA record" do
+            expect(subject.dns_zone_soa?).to be_truthy
+          end
+        end
+      end
+
       context "a domain with an MX record" do
         let(:domain) { "blog.parkermoore.de" }
         before(:each) do


### PR DESCRIPTION
In https://github.com/github/pages-health-check/pull/127 we take the approach to abstract SOA record checking from callers to `apex_domain?`.  Existing callers make assumptions around this value not being a subdomain so we may introduce bugs by adding additional logic to the function.

This PR instead exposes the new `dns_zone_soa?` method so that callers can take both pieces of information into account when deciding how to handle cases where subdomains behave like apex domains by having SOA records published.

See also https://github.com/github/pages-health-check/pull/129 for previous reviews.