### PR TITLE
chore: bump `public_suffix` past ~> 2.0

### DIFF
--- a/github-pages-health-check.gemspec
+++ b/github-pages-health-check.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency("addressable", "~> 2.3")
   s.add_dependency("dnsruby", "~> 1.60")
   s.add_dependency("octokit", "~> 4.0")
-  s.add_dependency("public_suffix", ">= 2.0.2", "< 5.0")
+  s.add_dependency("public_suffix", ">= 4.0.6", "< 5.0")
   s.add_dependency("typhoeus", "~> 1.3")
 end

--- a/github-pages-health-check.gemspec
+++ b/github-pages-health-check.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency("addressable", "~> 2.3")
   s.add_dependency("dnsruby", "~> 1.60")
   s.add_dependency("octokit", "~> 4.0")
-  s.add_dependency("public_suffix", ">= 4.0.6", "< 5.0")
+  s.add_dependency("public_suffix", "~> 4.0")
   s.add_dependency("typhoeus", "~> 1.3")
 end

--- a/github-pages-health-check.gemspec
+++ b/github-pages-health-check.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency("addressable", "~> 2.3")
   s.add_dependency("dnsruby", "~> 1.60")
   s.add_dependency("octokit", "~> 4.0")
-  s.add_dependency("public_suffix", "~> 3.0", "~> 4.0")
+  s.add_dependency("public_suffix", ">= 3.0", "< 5.0")
   s.add_dependency("typhoeus", "~> 1.3")
 end

--- a/github-pages-health-check.gemspec
+++ b/github-pages-health-check.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency("addressable", "~> 2.3")
   s.add_dependency("dnsruby", "~> 1.60")
   s.add_dependency("octokit", "~> 4.0")
-  s.add_dependency("public_suffix", "~> 4.0")
+  s.add_dependency("public_suffix", "~> 3.0", "~> 4.0")
   s.add_dependency("typhoeus", "~> 1.3")
 end


### PR DESCRIPTION
Resolves an issue when attempting to vendor this project:

```sh
Bundler could not find compatible versions for gem "public_suffix":
  In snapshot (Gemfile.lock):
    public_suffix (= 4.0.6)

  In Gemfile:
    public_suffix (~> 4.0)

    github-pages-health-check (= 1.7.4) was resolved to 1.7.4, which depends on
      public_suffix (~> 2.0)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

/cc https://github.com/github/pages-health-check/pull/116: prior art