### PR TITLE
fix(domain): suppress invalid A record error if SOA record exists

### DIFF
--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -135,7 +135,7 @@ module GitHubPages
       def invalid_a_record?
         return @invalid_a_record if defined? @invalid_a_record
 
-        @invalid_a_record = (valid_domain? && a_record? && !should_be_a_record?)
+        @invalid_a_record = (valid_domain? && a_record? && !should_be_a_record? && !dns_zone_soa?)
       end
 
       def invalid_cname?

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -135,7 +135,12 @@ module GitHubPages
       def invalid_a_record?
         return @invalid_a_record if defined? @invalid_a_record
 
-        @invalid_a_record = (valid_domain? && a_record? && !should_be_a_record? && !dns_zone_soa?)
+        @invalid_a_record = (
+          valid_domain? &&
+          a_record? &&
+          !should_be_a_record? &&
+          !dns_zone_soa?
+        )
       end
 
       def invalid_cname?

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -159,6 +159,11 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
       expect(subject).to be_a_invalid_a_record
     end
 
+    it "knows when a domain is not invalid if it has an SOA record" do
+      allow(subject).to receive(:dns) { [soa_packet] }
+      expect(subject).not_to be_a_invalid_a_record
+    end
+
     context "AAAA records" do
       let(:domain) { "parkermoore.de" }
       let(:ip) { "185.199.108.153" }


### PR DESCRIPTION
When a domain has an [SOA record](https://en.wikipedia.org/wiki/SOA_record) present, [concerns around use of a CNAME](https://www.isc.org/blogs/cname-at-the-apex-of-a-zone/) are reduced. In line with this, changes here relax our criteria around what an invalid A record is.  We now suppress messages where we're recommending users setup a CNAME on a subdomain that behaves similarly to the "apex" of a zone.