### PR TITLE
IPv6 fix

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,7 +52,7 @@ Style/ClassAndModuleChildren:
   Enabled: false # module X<\n>module Y is just as good as module X::Y.
 
 Layout/LineLength:
-  Max: 90
+  Max: 120
   Severity: warning
   Exclude:
     - github-pages-health-check.gemspec

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -89,7 +89,7 @@ module GitHubPages
 
       HASH_METHODS = %i[
         host uri nameservers dns_resolves? proxied? cloudflare_ip?
-        fastly_ip? old_ip_address? a_record? aaaa_record? aaaa_record_present?
+        fastly_ip? old_ip_address? a_record? aaaa_record? a_record_present? aaaa_record_present?
         cname_record? mx_records_present? valid_domain? apex_domain?
         should_be_a_record? cname_to_github_user_domain?
         cname_to_pages_dot_github_dot_com? cname_to_fastly?
@@ -138,14 +138,13 @@ module GitHubPages
       def invalid_aaaa_record?
         return @invalid_aaaa_record if defined? @invalid_aaaa_record
 
-        @invalid_aaaa_record =
-          (valid_domain? && aaaa_record_present? && !should_be_a_record?)
+        @invalid_aaaa_record = (valid_domain? && aaaa_record_present? && !should_be_a_record?)
       end
 
       def invalid_a_record?
         return @invalid_a_record if defined? @invalid_a_record
 
-        @invalid_a_record = (valid_domain? && a_record? && !should_be_a_record?)
+        @invalid_a_record = (valid_domain? && a_record_present? && !should_be_a_record?)
       end
 
       def invalid_cname?
@@ -369,10 +368,18 @@ module GitHubPages
         @is_aaaa_record = Dnsruby::Types::AAAA == dns.first.type
       end
 
+      # Does this domain has an A record setup (not necessarily as the first record)?
+      def a_record_present?
+        return unless dns?
+
+        dns.any? { |answer| answer.type == Dnsruby::Types::A && answer.name.to_s == host }
+      end
+
+      # Does this domain has an AAAA record setup (not necessarily as the first record)?
       def aaaa_record_present?
         return unless dns?
 
-        dns.any? { |answer| answer.type == Dnsruby::Types::AAAA }
+        dns.any? { |answer| answer.type == Dnsruby::Types::AAAA && answer.name.to_s == host }
       end
 
       # Is this domain's first response a CNAME record?

--- a/lib/github-pages-health-check/errors/invalid_aaaa_record_error.rb
+++ b/lib/github-pages-health-check/errors/invalid_aaaa_record_error.rb
@@ -8,9 +8,9 @@ module GitHubPages
 
         def message
           <<-MSG
-             Your site's DNS settings are using a custom subdomain, #{domain.host},
-             that's set up with an AAAA record. GitHub Pages currently does not support
-             IPv6.
+          Your site's DNS settings are using a custom subdomain, #{domain.host},
+          that's set up as an AAAA record. We recommend you change this to a CNAME
+          record pointing at #{username}.github.io.
           MSG
         end
       end

--- a/lib/github-pages-health-check/version.rb
+++ b/lib/github-pages-health-check/version.rb
@@ -2,6 +2,6 @@
 
 module GitHubPages
   module HealthCheck
-    VERSION = "1.17.8"
+    VERSION = "1.17.9"
   end
 end

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -180,6 +180,25 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
     end
   end
 
+  context "A & AAAA recursive resolutions" do
+    let(:domain) { "domain.com" }
+    let(:cname) { "domain.github.io" }
+    before(:each) do
+      allow(subject).to receive(:dns) {
+        [
+          cname_packet,
+          Dnsruby::RR.create("#{cname}. 1000 IN A #{ip}"),
+          Dnsruby::RR.create("#{cname}. 1000 IN AAAA #{ip6}")
+        ]
+      }
+    end
+
+    it "does not get tricked by recursive resolution" do
+      expect(subject).to_not be_an_aaaa_record_present
+      expect(subject).to_not be_an_a_record_present
+    end
+  end
+
   context "CNAMEs" do
     before(:each) { allow(subject).to receive(:dns) { [cname_packet] } }
 


### PR DESCRIPTION
This PR fixes logic related to our recent rollout of IPv6 for Pages.

`AAAA` record presence is now also looking at the actual record name not to be confused by a `CNAME` resolution.

For instance in:

```
dig AAAA pages.github.com

; <<>> DiG 9.10.6 <<>> AAAA pages.github.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 35585
;; flags: qr rd ra; QUERY: 1, ANSWER: 5, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;pages.github.com.		IN	AAAA

;; ANSWER SECTION:
pages.github.com.	3600	IN	CNAME	github.github.io.
github.github.io.	1451	IN	AAAA	2606:50c0:8000::153
github.github.io.	1451	IN	AAAA	2606:50c0:8001::153
github.github.io.	1451	IN	AAAA	2606:50c0:8002::153
github.github.io.	1451	IN	AAAA	2606:50c0:8003::153
```

We used to consider `AAAA` record were present on the zone while they are not. They are resolved via the `CNAME` record.

cc/ https://github.com/github/pages-engineering/issues/787