### PR TITLE
Allow all of the matrix builds to run despite failures

### DIFF
--- a/.github/workflows/push-cibuild.yml
+++ b/.github/workflows/push-cibuild.yml
@@ -8,11 +8,11 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.6
-          - 2.7
-          - 3.0
-          - 3.1
-          - 3.2
+          - '2.6'
+          - '2.7'
+          - '3.0'
+          - '3.1'
+          - '3.2'
     steps:
     - uses: actions/checkout@master
     - name: script/cibuild-docker

--- a/.github/workflows/push-cibuild.yml
+++ b/.github/workflows/push-cibuild.yml
@@ -8,10 +8,11 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.5
           - 2.6
           - 2.7
           - 3.0
+          - 3.1
+          - 3.2
     steps:
     - uses: actions/checkout@master
     - name: script/cibuild-docker

--- a/.github/workflows/push-cibuild.yml
+++ b/.github/workflows/push-cibuild.yml
@@ -5,6 +5,7 @@ jobs:
     name: "GitHub Pages Health Check Tests"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby:
           - 2.5


### PR DESCRIPTION
Actions matrix strategy implies a default of `fail-fast: true`. This saves compute resources but also makes it more hard to determine if a failure if version-specific. 😅 

Let's let them all run since the list is relatively small anyway. 🤷🏻 

**Edit:** Also update the Ruby support matrix based on the official Docker image availability.