### PR TITLE
Remove the broken Travis CI badge

### DIFF
--- a/.github/workflows/push-cibuild.yml
+++ b/.github/workflows/push-cibuild.yml
@@ -1,5 +1,5 @@
 on: push
-name: cibuild on push
+name: "GitHub Pages Health Check Tests"
 jobs:
   build:
     name: "GitHub Pages Health Check Tests"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 *Checks your GitHub Pages site for common DNS configuration issues*
 
-![Build Status](https://github.com/github/pages-health-check/actions/workflows/push-cibuild.yml/badge.svg)
+[![Build Status](https://github.com/github/pages-health-check/actions/workflows/push-cibuild.yml/badge.svg)](https://github.com/github/pages-health-check/actions/workflows/push-cibuild.yml)
 [![Gem Version](https://badge.fury.io/rb/github-pages-health-check.svg)](http://badge.fury.io/rb/github-pages-health-check)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 *Checks your GitHub Pages site for common DNS configuration issues*
 
+![Build Status](https://github.com/github/pages-health-check/actions/workflows/push-cibuild.yml/badge.svg)
 [![Gem Version](https://badge.fury.io/rb/github-pages-health-check.svg)](http://badge.fury.io/rb/github-pages-health-check)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 *Checks your GitHub Pages site for common DNS configuration issues*
 
-[![Build Status](https://travis-ci.org/github/pages-health-check.svg)](https://travis-ci.org/github/pages-health-check) [![Gem Version](https://badge.fury.io/rb/github-pages-health-check.svg)](http://badge.fury.io/rb/github-pages-health-check)
+[![Gem Version](https://badge.fury.io/rb/github-pages-health-check.svg)](http://badge.fury.io/rb/github-pages-health-check)
 
 ## Installation
 


### PR DESCRIPTION
Noticed this while looking at the README and thought it would be good to get rid of the broken link.

