### PR TITLE
Custom domain simplifaction

### DIFF
--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -416,7 +416,7 @@ module GitHubPages
 
       # Check if we have a 'www.' CNAME that matches the domain
       def www_cname(cname)
-        @wwwcname || = cname.name.to_s.start_with("www.") &&
+        @wwwcname ||= cname.name.to_s.start_with("www.") &&
           cname.name.to_s.end_with?(cname.domainname.to_s)
       end
 

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -411,7 +411,9 @@ module GitHubPages
         return if cnames.empty?
 
         # check to see if the CNAME starts with www and domain name is the same
-        @wwwcname ||= cnames.last.name.to_s.start_with?("www") && cnames.last.name.to_s.end_with?(cnames.last.domainname.to_s)
+        @wwwcname ||= cnames.last.name.to_s.start_with?("www") &&
+          cnames.last.name.to_s.end_with?(cnames.last.domainname.to_s)
+
         @cname ||= Domain.new(cnames.last.cname.to_s)
       end
 

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -248,7 +248,7 @@ module GitHubPages
       def cname_to_domain_to_pages?
         a_record_to_pages = dns.select { |d| d.type == Dnsruby::Types::A && d.name.to_s == host }.first
 
-        return false unless a_record_to_pages && cname? && !cname_to_pages_dot_github_dot_com?
+        return false unless a_record_to_pages && cname? && !cname_to_pages_dot_github_dot_com? && @wwwcname
 
         CURRENT_IP_ADDRESSES.include?(a_record_to_pages.address.to_s.downcase)
       end
@@ -410,6 +410,8 @@ module GitHubPages
         cnames = dns.take_while { |answer| answer.type == Dnsruby::Types::CNAME }
         return if cnames.empty?
 
+        # check to see if the CNAME starts with www
+        @wwwcname ||= cnames.last.name.to_s.start_with?("www")
         @cname ||= Domain.new(cnames.last.cname.to_s)
       end
 

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -244,7 +244,8 @@ module GitHubPages
         # domain.
         #
         # e.g 'www.domain.com' -> 'domain.com' -> 'Pages' is valid
-        cname? && !cname_to_pages_dot_github_dot_com? && (cname.pages_domain? || Domain.redundant(host))
+        binding.pry
+        cname? && !cname_to_pages_dot_github_dot_com? && (cname.pages_domain?)
       end
 
       # Is the given domain a CNAME to pages.github.(io|com)

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -248,7 +248,7 @@ module GitHubPages
       def cname_to_domain_to_pages?
         a_record_to_pages = dns.select { |d| d.type == Dnsruby::Types::A && d.name.to_s == host }.first
 
-        return false unless a_record_to_pages && cname? && !cname_to_pages_dot_github_dot_com? && @wwwcname
+        return false unless a_record_to_pages && cname? && !cname_to_pages_dot_github_dot_com? && @www_cname
 
         CURRENT_IP_ADDRESSES.include?(a_record_to_pages.address.to_s.downcase)
       end
@@ -416,7 +416,7 @@ module GitHubPages
 
       # Check if we have a 'www.' CNAME that matches the domain
       def www_cname(cname)
-        @wwwcname ||= cname.name.to_s.start_with?("www.") &&
+        @www_cname ||= cname.name.to_s.start_with?("www.") &&
           cname.name.to_s.end_with?(cname.domainname.to_s)
       end
 

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -410,8 +410,8 @@ module GitHubPages
         cnames = dns.take_while { |answer| answer.type == Dnsruby::Types::CNAME }
         return if cnames.empty?
 
-        # check to see if the CNAME starts with www
-        @wwwcname ||= cnames.last.name.to_s.start_with?("www")
+        # check to see if the CNAME starts with www and domain name is the same
+        @wwwcname ||= cnames.last.name.to_s.start_with?("www") && cnames.last.name.to_s.end_with?(cnames.last.domainname.to_s)
         @cname ||= Domain.new(cnames.last.cname.to_s)
       end
 

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -245,11 +245,13 @@ module GitHubPages
         #
         # e.g 'www.domain.com' -> 'domain.com' -> 'Pages' is valid
         if cname? && !cname_to_pages_dot_github_dot_com?
-          # Check if the host does point to 'Pages'
+          # CNAME points to Pages
           if cname.pages_domain?
             return true
+          # CNAME points to a domain which might point to Pages
+          else
+            return Domain.redundant(host)
           end
-          # CNAME points to 'Pages' nothing left to do
         end
       end
 

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -238,19 +238,18 @@ module GitHubPages
           .any? { |a| !github_pages_ip?(a.address.to_s) }
       end
 
-      # Is the domain's first response a CNAME to a pages domain?
+      # Is the domain's first response a CNAME to a pages domain or a domain to pages?
       def cname_to_github_user_domain?
         # If the domain does not match check if the host value points to a pages
         # domain.
         #
         # e.g 'www.domain.com' -> 'domain.com' -> 'Pages' is valid
-        if cname? && !cname_to_pages_dot_github_dot_com? && !cname.pages_domain?
+        if cname? && !cname_to_pages_dot_github_dot_com?
           # Check if the host does point to 'Pages'
-          if !cname.pages_domain?
-            return self.redundant(host)
+          if cname.pages_domain?
+            return true
           end
           # CNAME points to 'Pages' nothing left to do
-          return true
         end
       end
 

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -410,7 +410,7 @@ module GitHubPages
         cnames = dns.take_while { |answer| answer.type == Dnsruby::Types::CNAME }
         return if cnames.empty?
 
-        www_cname(cname.last)
+        www_cname(cnames.last)
         @cname ||= Domain.new(cnames.last.cname.to_s)
       end
 

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -416,7 +416,7 @@ module GitHubPages
 
       # Check if we have a 'www.' CNAME that matches the domain
       def www_cname(cname)
-        @wwwcname ||= cname.name.to_s.start_with("www.") &&
+        @wwwcname ||= cname.name.to_s.start_with?("www.") &&
           cname.name.to_s.end_with?(cname.domainname.to_s)
       end
 

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -410,11 +410,14 @@ module GitHubPages
         cnames = dns.take_while { |answer| answer.type == Dnsruby::Types::CNAME }
         return if cnames.empty?
 
-        # check to see if the CNAME starts with www and domain name is the same
-        @wwwcname ||= cnames.last.name.to_s.start_with?("www") &&
-          cnames.last.name.to_s.end_with?(cnames.last.domainname.to_s)
-
+        www_cname(cname.last)
         @cname ||= Domain.new(cnames.last.cname.to_s)
+      end
+
+      # Check if we have a 'www.' CNAME that matches the domain
+      def www_cname(cname)
+        @wwwcname || = cname.name.to_s.start_with("www.") &&
+          cname.name.to_s.end_with?(cname.domainname.to_s)
       end
 
       def mx_records_present?

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -243,11 +243,13 @@ module GitHubPages
         cname? && !cname_to_pages_dot_github_dot_com? && cname.pages_domain?
       end
 
-      # Check if the CNAME points to a Domain that points to pages 
-      # e.g. CNAME -> Domain -> Pages 
+      # Check if the CNAME points to a Domain that points to pages
+      # e.g. CNAME -> Domain -> Pages
       def cname_to_domain_to_pages?
         a_record_to_pages = dns.select { |d| d.type == Dnsruby::Types::A && d.name.to_s == host }.first
+
         return false unless a_record_to_pages && cname? && !cname_to_pages_dot_github_dot_com?
+
         CURRENT_IP_ADDRESSES.include?(a_record_to_pages.address.to_s.downcase)
       end
 

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -91,7 +91,7 @@ module GitHubPages
         host uri nameservers dns_resolves? proxied? cloudflare_ip?
         fastly_ip? old_ip_address? a_record? aaaa_record? a_record_present? aaaa_record_present?
         cname_record? mx_records_present? valid_domain? apex_domain?
-        should_be_a_record? cname_to_github_user_domain?
+        should_be_a_record? cname_to_github_user_domain? cname_to_domain_to_pages?
         cname_to_pages_dot_github_dot_com? cname_to_fastly?
         pointed_to_github_pages_ip? non_github_pages_ip_present? pages_domain?
         served_by_pages? valid? reason valid_domain? https?
@@ -240,12 +240,15 @@ module GitHubPages
 
       # Is the domain's first response a CNAME to a pages domain?
       def cname_to_github_user_domain?
-        # If the domain does not match check if the host value points to a pages
-        # domain.
-        #
-        # e.g 'www.domain.com' -> 'domain.com' -> 'Pages' is valid
-        binding.pry
-        cname? && !cname_to_pages_dot_github_dot_com? && (cname.pages_domain?)
+        cname? && !cname_to_pages_dot_github_dot_com? && cname.pages_domain?
+      end
+
+      # Check if the CNAME points to a Domain that points to pages 
+      # e.g. CNAME -> Domain -> Pages 
+      def cname_to_domain_to_pages?
+        a_record_to_pages = dns.select { |d| d.type == Dnsruby::Types::A && d.name.to_s == host }.first
+        return false unless a_record_to_pages && cname? && !cname_to_pages_dot_github_dot_com?
+        CURRENT_IP_ADDRESSES.include?(a_record_to_pages.address.to_s.downcase)
       end
 
       # Is the given domain a CNAME to pages.github.(io|com)
@@ -309,6 +312,7 @@ module GitHubPages
         return true if cloudflare_ip?
         return false if pointed_to_github_pages_ip?
         return false if cname_to_github_user_domain?
+        return false if cname_to_domain_to_pages?
         return false if cname_to_pages_dot_github_dot_com?
         return false if cname_to_fastly? || fastly_ip?
 
@@ -459,8 +463,7 @@ module GitHubPages
         return false if host.include?("_")
 
         # Must be a CNAME or point to our IPs.
-        # Only check the one domain if a CNAME. Don't check the parent domain.
-        return true if cname_to_github_user_domain?
+        return true if cname_to_github_user_domain? || cname_to_domain_to_pages?
 
         # Check CAA records for the full domain and its parent domain.
         pointed_to_github_pages_ip? && caa.lets_encrypt_allowed?

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -240,7 +240,18 @@ module GitHubPages
 
       # Is the domain's first response a CNAME to a pages domain?
       def cname_to_github_user_domain?
-        cname? && !cname_to_pages_dot_github_dot_com? && cname.pages_domain?
+        # If the domain does not match check if the host value points to a pages
+        # domain.
+        #
+        # e.g 'www.domain.com' -> 'domain.com' -> 'Pages' is valid
+        if cname? && !cname_to_pages_dot_github_dot_com? && !cname.pages_domain?
+          # Check if the host does point to 'Pages'
+          if !cname.pages_domain?
+            return self.redundant(host)
+          end
+          # CNAME points to 'Pages' nothing left to do
+          return true
+        end
       end
 
       # Is the given domain a CNAME to pages.github.(io|com)

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -238,21 +238,13 @@ module GitHubPages
           .any? { |a| !github_pages_ip?(a.address.to_s) }
       end
 
-      # Is the domain's first response a CNAME to a pages domain or a domain to pages?
+      # Is the domain's first response a CNAME to a pages domain?
       def cname_to_github_user_domain?
         # If the domain does not match check if the host value points to a pages
         # domain.
         #
         # e.g 'www.domain.com' -> 'domain.com' -> 'Pages' is valid
-        if cname? && !cname_to_pages_dot_github_dot_com?
-          # CNAME points to Pages
-          if cname.pages_domain?
-            return true
-          # CNAME points to a domain which might point to Pages
-          else
-            return Domain.redundant(host)
-          end
-        end
+        cname? && !cname_to_pages_dot_github_dot_com? && (cname.pages_domain? || Domain.redundant(host))
       end
 
       # Is the given domain a CNAME to pages.github.(io|com)

--- a/lib/github-pages-health-check/version.rb
+++ b/lib/github-pages-health-check/version.rb
@@ -2,6 +2,6 @@
 
 module GitHubPages
   module HealthCheck
-    VERSION = "1.18.2"
+    VERSION = "1.18.3"
   end
 end

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -240,6 +240,29 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
       end
     end
 
+    context "CNAME to Domain to Pages", focus: true do
+      let(:cname) { "www.fontawesome.it" }
+      let(:domain) { "fontawesome.it" }
+      let(:ip) { "185.199.108.153" }
+      before do
+        allow(subject).to receive(:dns) do
+          [
+            Dnsruby::RR.create("#{cname}. 1000 IN CNAME #{domain}"),
+            a_packet,
+          ]
+        end
+      end
+
+      it "follows the CNAMEs all the way down" do
+        expect(subject.cname.host).to eq("fontawesome.it")
+      end
+
+      it "knows it's a Pages IP at the end" do
+        binding.require 'pry'; binding.pry
+      end
+    end
+
+
     context "broken CNAMEs" do
       before do
         allow(subject).to receive(:dns) do

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -262,7 +262,6 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
       end
     end
 
-
     context "broken CNAMEs" do
       before do
         allow(subject).to receive(:dns) do

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
       let(:cname) { "www.fontawesome.it" }
       let(:domain) { "fontawesome.it" }
       let(:ip) { "185.199.108.153" }
-      before do
+      before(:each) do
         allow(subject).to receive(:dns) do
           [
             Dnsruby::RR.create("#{cname}. 1000 IN CNAME #{domain}"),
@@ -259,6 +259,24 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
 
       it "knows it's a Pages IP at the end" do
         expect(subject).to be_a_cname_to_domain_to_pages
+      end
+    end
+
+    context "CNAME to Domain that doesn't go to Pages" do
+      let(:cname) { "www.fontawesome.it" }
+      let(:domain) { "fontawesome.it" }
+      let(:ip) { "127.0.0.1" }
+      before(:each) do
+        allow(subject).to receive(:dns) do
+          [
+            Dnsruby::RR.create("#{cname}. 1000 IN CNAME #{domain}"),
+            a_packet
+          ]
+        end
+      end
+
+      if "knows it's not a Pages IP at the end" do
+        expect(subject).to_not be_a_cname_to_domain_to_pages
       end
     end
 

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
       end
     end
 
-    context "CNAME to Domain to Pages", focus: true do
+    context "CNAME to Domain to Pages" do
       let(:cname) { "www.fontawesome.it" }
       let(:domain) { "fontawesome.it" }
       let(:ip) { "185.199.108.153" }
@@ -248,7 +248,7 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
         allow(subject).to receive(:dns) do
           [
             Dnsruby::RR.create("#{cname}. 1000 IN CNAME #{domain}"),
-            a_packet,
+            a_packet
           ]
         end
       end

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
         end
       end
 
-      if "knows it's not a Pages IP at the end" do
+      it "knows it's not a Pages IP at the end" do
         expect(subject).to_not be_a_cname_to_domain_to_pages
       end
     end

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
       end
 
       it "knows it's a Pages IP at the end" do
-        expect(subject).to be_a_cname_to_domain_to_pages
+        expect(subject).to_not be_a_cname_to_domain_to_pages
       end
     end
 

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
         end
       end
 
-      it "knows it's a Pages IP at the end" do
+      it "CNAME does not start with www and no match to host" do
         expect(subject).to_not be_a_cname_to_domain_to_pages
       end
     end

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -429,6 +429,22 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
           expect(subject).to be_a_cname_to_github_user_domain
         end
       end
+
+      focus
+      context "to domain that points to pages" do
+        let(:cname) { "octocat.com" }
+        before do
+          allow(subject).to receive(:dns) do
+            [
+              Dnsruby::RR.create("#{cname}. 1000 IN CNAME example.com"),
+              Dnsruby::RR.create("example.com 1000 IN A 192.168.0.1")
+            ]
+          end
+        end
+        
+        it "follows the CNAME all the way down" do
+        end
+      end
     end
   end
 

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
       end
 
       it "knows it's a Pages IP at the end" do
-        binding.require 'pry'; binding.pry
+        expect(subject).to be_a_cname_to_domain_to_pages
       end
     end
 

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -262,6 +262,24 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
       end
     end
 
+    context "Random CNAME to Domain that goes to Pages" do
+      let(:cname) { "monalisa" }
+      let(:domain) { "fontawesome.it" }
+      let(:ip) { "185.199.108.153" }
+      before(:each) do
+        allow(subject).to receive(:dns) do
+          [
+            Dnsruby::RR.create("#{cname}. 1000 IN CNAME #{domain}"),
+            a_packet
+          ]
+        end
+      end
+
+      it "knows it's a Pages IP at the end" do
+        expect(subject).to be_a_cname_to_domain_to_pages
+      end
+    end
+
     context "CNAME to Domain that doesn't go to Pages" do
       let(:cname) { "www.fontawesome.it" }
       let(:domain) { "fontawesome.it" }

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -280,6 +280,42 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
       end
     end
 
+    context "CNAME with same host but no www" do
+      let(:cname) { "blog.fontawesome.it" }
+      let(:domain) { "fontawesome.it" }
+      let(:ip) { "185.199.108.153" }
+      before(:each) do
+        allow(subject).to receive(:dns) do
+          [
+            Dnsruby::RR.create("#{cname}. 1000 IN CNAME #{domain}"),
+            a_packet
+          ]
+        end
+      end
+
+      it "CNAME does not start with www and no match to host" do
+        expect(subject).to_not be_a_cname_to_domain_to_pages
+      end
+    end
+
+    context "CNAME starts with www but different host" do
+      let(:cname) { "www.fontawesome.it" }
+      let(:domain) { "awesomefont.it" }
+      let(:ip) { "185.199.108.153" }
+      before(:each) do
+        allow(subject).to receive(:dns) do
+          [
+            Dnsruby::RR.create("#{cname}. 1000 IN CNAME #{domain}"),
+            a_packet
+          ]
+        end
+      end
+
+      it "CNAME does not match to host" do
+        expect(subject).to_not be_a_cname_to_domain_to_pages
+      end
+    end
+
     context "CNAME to Domain that doesn't go to Pages" do
       let(:cname) { "www.fontawesome.it" }
       let(:domain) { "fontawesome.it" }

--- a/spec/github_pages_health_check/domain_spec.rb
+++ b/spec/github_pages_health_check/domain_spec.rb
@@ -429,22 +429,6 @@ RSpec.describe(GitHubPages::HealthCheck::Domain) do
           expect(subject).to be_a_cname_to_github_user_domain
         end
       end
-
-      focus
-      context "to domain that points to pages" do
-        let(:cname) { "octocat.com" }
-        before do
-          allow(subject).to receive(:dns) do
-            [
-              Dnsruby::RR.create("#{cname}. 1000 IN CNAME example.com"),
-              Dnsruby::RR.create("example.com 1000 IN A 192.168.0.1")
-            ]
-          end
-        end
-        
-        it "follows the CNAME all the way down" do
-        end
-      end
     end
   end
 


### PR DESCRIPTION
closes: https://github.com/github/pages-engineering/issues/4205

Relaxes the validation process for `CNAME` by checking if the domain it points to points to GitHub Pages. This is done by creating a new method which checks if there is a record of type `A` in the DNS to which the `CNAME` points to. If this is the case then we just check if that points to Pages. 