### PR TITLE
Fix github.com matching

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Automatically add our team to each pull request in this repo
+* @github/pages-reviewers

--- a/lib/github-pages-health-check/domain.rb
+++ b/lib/github-pages-health-check/domain.rb
@@ -283,7 +283,7 @@ module GitHubPages
 
       # Is this domain owned by GitHub?
       def github_domain?
-        !!host.downcase.end_with?("github.com")
+        !!host.match(/(\A|\.)github\.com\.?\z/i)
       end
 
       # Is the host our Fastly CNAME?


### PR DESCRIPTION
This PR addresses https://github.com/github/pages-health-check/security/code-scanning/1.

It just does better URL handling by relaying on a regular expression.