### PR TITLE
Use correct keyword argument when creating Dnsruby::Resolver

### DIFF
--- a/lib/github-pages-health-check/resolver.rb
+++ b/lib/github-pages-health-check/resolver.rb
@@ -43,15 +43,15 @@ module GitHubPages
                         self.class.default_resolver
                       when :authoritative
                         Dnsruby::Resolver.new(DEFAULT_RESOLVER_OPTIONS.merge(
-                                                :nameservers => authoritative_nameservers
+                                                :nameserver => authoritative_nameservers
                                               ))
                       when :public
                         Dnsruby::Resolver.new(DEFAULT_RESOLVER_OPTIONS.merge(
-                                                :nameservers => PUBLIC_NAMESERVERS
+                                                :nameserver => PUBLIC_NAMESERVERS
                                               ))
                       when Array
                         Dnsruby::Resolver.new(DEFAULT_RESOLVER_OPTIONS.merge(
-                                                :nameservers => nameservers
+                                                :nameserver => nameservers
                                               ))
                       else
                         raise "Invalid nameserver type: #{nameservers.inspect}"


### PR DESCRIPTION
This is a typo. See https://www.rubydoc.info/gems/dnsruby/Dnsruby%2FResolver:initialize