### PR TITLE
Add Domain.maybe_wildcard? to detect possible wilcard DNS records

### DIFF
--- a/github-pages-health-check.gemspec
+++ b/github-pages-health-check.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files                 = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   s.require_paths         = ["lib"]
 
-  s.add_dependency("addressable", "~> 2.3")
+  s.add_dependency("addressable", "~> 2.8.7")
   s.add_dependency("dnsruby", "~> 1.60")
   s.add_dependency("octokit", ">= 4", "< 10")
   s.add_dependency("public_suffix", ">= 3.0", "< 7.0")

--- a/lib/github-pages-health-check/errors/wildcard_record_error.rb
+++ b/lib/github-pages-health-check/errors/wildcard_record_error.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module GitHubPages
+  module HealthCheck
+    module Errors
+      class WildcardRecordError < GitHubPages::HealthCheck::Error
+        DOCUMENTATION_PATH = "/pages/configuring-a-custom-domain-for-your-github-pages-site/verifying-your-custom-domain-for-github-pages/"
+
+        attr_reader :parent_domain
+
+        def initialize(repository: nil, domain: nil, parent_domain: nil)
+          super(:repository => repository, :domain => domain)
+          @parent_domain = parent_domain
+        end
+
+        def message
+          <<-MSG
+            The DNS record for your domain appears to be *.#{parent_domain}, a wildcard record.
+            Your GitHub Pages site will still work, but unless you verify ownership of #{parent_domain},
+            any GitHub Pages user can serve their content from an arbitrary subdomain of it.
+          MSG
+        end
+      end
+    end
+  end
+end

--- a/spec/github_pages_health_check/errors_spec.rb
+++ b/spec/github_pages_health_check/errors_spec.rb
@@ -4,6 +4,6 @@ require "spec_helper"
 
 RSpec.describe(GitHubPages::HealthCheck::Errors) do
   it "returns the errors" do
-    expect(GitHubPages::HealthCheck::Errors.all.count).to eql(10)
+    expect(GitHubPages::HealthCheck::Errors.all.count).to eql(11)
   end
 end


### PR DESCRIPTION
`Domain#maybe_wildcard?` generates a random sibling domain and queries it, then checks if it returns an answer and if it points to github pages. If so, then it's reasonable to suspect that the record which points the domain to github pages is a wildcard record.

This is worth warning about because a wildcard DNS record will allow anyone to host a pages site at a subdomain of the wildcard record. GitHub allows us to verify ownership of our domains, but it only works for the verified domain and direct subdomains (a.example.com, b.example.com), not subdomains arbitrarily many segments long (a.b.c.d.e.f.example.com).